### PR TITLE
[Feat] 유저 전적 로직 구현

### DIFF
--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -198,6 +198,7 @@ public class RoundService {
         if (round.isTiebreaker()) {
             roundWinner.markWinner();
             room.finishGame();
+            recordGameResults(room, roundWinner);
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
@@ -259,6 +260,7 @@ public class RoundService {
             Participant finalWinner = topScorers.get(0);
             finalWinner.markWinner();
             room.finishGame();
+            recordGameResults(room, finalWinner);
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
@@ -329,6 +331,17 @@ public class RoundService {
         tieBreakerRound.start();
 
         return roundRepository.save(tieBreakerRound);
+    }
+
+    /**
+     * 게임 종료 시 전원 totalGameCount +1, 최종 우승자 winGameCount +1
+     */
+    private void recordGameResults(Room room, Participant winner) {
+        List<Participant> participants = participantRepository.findByRoomId(room.getId());
+
+        participants.forEach(p -> p.getUserId().getStats().recordGame());
+
+        winner.getUserId().getStats().recordWin();
     }
 
     /**

--- a/src/main/java/backend/drawrace/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/backend/drawrace/domain/user/dto/UserInfoResponse.java
@@ -12,6 +12,8 @@ public class UserInfoResponse {
     private String email;
     private String nickname;
     private String profileImageUrl;
+    private int totalGameCount;
+    private int winGameCount;
 
     public static UserInfoResponse from(User user) {
         return UserInfoResponse.builder()
@@ -19,6 +21,8 @@ public class UserInfoResponse {
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
+                .totalGameCount(user.getStats().getTotalGameCount())
+                .winGameCount(user.getStats().getWinGameCount())
                 .build();
     }
 }

--- a/src/main/java/backend/drawrace/domain/user/entity/UserStats.java
+++ b/src/main/java/backend/drawrace/domain/user/entity/UserStats.java
@@ -32,4 +32,12 @@ public class UserStats extends BaseEntity {
         this.totalGameCount = totalGameCount;
         this.winGameCount = winGameCount;
     }
+
+    public void recordGame() {
+        this.totalGameCount++;
+    }
+
+    public void recordWin() {
+        this.winGameCount++;
+    }
 }

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -36,6 +36,7 @@ import backend.drawrace.domain.round.repository.RoundRepository;
 import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.round.validator.RoundValidator;
 import backend.drawrace.domain.user.entity.User;
+import backend.drawrace.domain.user.entity.UserStats;
 
 @ExtendWith(MockitoExtension.class)
 class RoundServiceTest {
@@ -255,6 +256,11 @@ class RoundServiceTest {
         assertThat(participant.getRoundWinCount()).isEqualTo(2);
         assertThat(participant.isWinner()).isTrue();
         assertThat(room.isPlaying()).isFalse();
+
+        then(participant.getUserId().getStats()).should().recordGame();
+        then(participant.getUserId().getStats()).should().recordWin();
+        then(participant2.getUserId().getStats()).should().recordGame();
+        then(participant2.getUserId().getStats()).shouldHaveNoMoreInteractions();
     }
 
     @Test
@@ -341,6 +347,7 @@ class RoundServiceTest {
         given(roundSubmissionRepository.countByRoundId(roundId)).willReturn(2L);
         given(roundParticipantRepository.countByRoundId(roundId)).willReturn(2L);
         given(roundSubmissionRepository.findByRoundId(roundId)).willReturn(List.of(currentSubmission, otherSubmission));
+        given(participantRepository.findByRoomId(roomId)).willReturn(List.of(participant, participant2));
 
         SubmitDrawingResponse response = roundService.submitDrawing(roundId, request);
 
@@ -353,6 +360,11 @@ class RoundServiceTest {
         assertThat(participant.getRoundWinCount()).isEqualTo(3);
         assertThat(participant.isWinner()).isTrue();
         assertThat(room.isPlaying()).isFalse();
+
+        then(participant.getUserId().getStats()).should().recordGame();
+        then(participant.getUserId().getStats()).should().recordWin();
+        then(participant2.getUserId().getStats()).should().recordGame();
+        then(participant2.getUserId().getStats()).shouldHaveNoMoreInteractions();
     }
 
     @Test
@@ -462,6 +474,8 @@ class RoundServiceTest {
 
     private Participant createParticipant(Long id, Room room, int roundWinCount) throws Exception {
         User user = mock(User.class);
+        UserStats stats = mock(UserStats.class);
+        lenient().when(user.getStats()).thenReturn(stats);
 
         Participant participant =
                 Participant.builder().userId(user).room(room).isHost(false).build();


### PR DESCRIPTION
## 📝 작업 내용
- 정상적인 게임 종료 후, 모든 참가자의 게임 참가 횟수가 1씩 증가한다.
- 정상적인 게임 종료 후, 최종 승리자의 게임 승리 횟수가 1 증가한다.
- 유저 정보 조회 시, 전적 내용이 함께 조회된다.

## 🔢 작업 단계
- [x] RoundService에 증가 로직 호출 구현
- [x] UserStats 엔티티에 증가 로직 구현
- [x] UserInfoResponse에 전적 필드 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [x] 빌드가 정상적으로 완료되었나요?
- [x] 테스트 코드를 작성하고 통과했나요?
- [x] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #15