### PR TITLE
[Feat] 실시간 게임 흐름 제어 및 방 관리

### DIFF
--- a/src/main/java/backend/drawrace/domain/room/controller/RoomController.java
+++ b/src/main/java/backend/drawrace/domain/room/controller/RoomController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,6 +13,7 @@ import backend.drawrace.domain.room.dto.request.JoinRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
+import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.service.RoomService;
 import backend.drawrace.global.rsdata.RsData;
 import backend.drawrace.global.security.SecurityUser;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class RoomController {
 
     private final RoomService roomService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     // 방 생성
     @PostMapping
@@ -49,13 +52,14 @@ public class RoomController {
 
     // 방 입장
     @PostMapping("/{roomId}/join")
-    public RsData<RoomInfoRes> joinRoom(
+    public RsData<RoomUpdateResponse> joinRoom(
             @PathVariable Long roomId,
             @RequestBody(required = false) JoinRoomReq req,
             @AuthenticationPrincipal SecurityUser securityUser) {
         String password = (req != null) ? req.password() : null;
-        RoomInfoRes detail = roomService.joinRoom(roomId, securityUser.getUserId(), password);
-        return new RsData<>("200-3", "방에 입장했습니다.", detail);
+        RoomUpdateResponse response = roomService.joinRoom(roomId, securityUser.getUserId(), password);
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
+        return new RsData<>("200-3", "방에 입장했습니다.", response);
     }
 
     // 게임 시작 요청
@@ -68,7 +72,14 @@ public class RoomController {
     // 방 퇴장
     @DeleteMapping("/{roomId}/leave")
     public RsData<Void> leaveRoom(@PathVariable Long roomId, @AuthenticationPrincipal SecurityUser securityUser) {
-        roomService.leaveRoom(roomId, securityUser.getUserId());
+        RoomUpdateResponse response = roomService.leaveRoom(securityUser.getUserId());
+
+        // 방에 남은 유저들에게 실시간으로 퇴장 및 방장 변경 정보를 전송
+        if (response != null) {
+            // 구독 경로: /sub/rooms/{roomId}
+            messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
+        }
+
         return new RsData<>("200-4", "방에서 성공적으로 퇴장했습니다.");
     }
 

--- a/src/main/java/backend/drawrace/domain/room/dto/response/RoomUpdateResponse.java
+++ b/src/main/java/backend/drawrace/domain/room/dto/response/RoomUpdateResponse.java
@@ -1,0 +1,17 @@
+package backend.drawrace.domain.room.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RoomUpdateResponse {
+    private Long roomId;
+    private String type; // "USER_LEAVE" 또는 "HOST_CHANGED"
+    private Long leaverId; // 나간 유저 ID
+    private Long newHostId; // 새 방장 ID (방장이 안 바뀌었으면 기존 방장 ID)
+    private List<String> participants; // 현재 방에 남은 유저 닉네임 리스트
+    private String message; // "OOO님이 퇴장하셨습니다."
+}

--- a/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
@@ -21,5 +21,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     Optional<Participant> findByRoomAndUserId(Room room, User user);
 
+    Optional<Participant> findByUserId(User user);
+
     boolean existsByRoomIdAndUserId_Id(Long roomId, Long userId);
 }

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -10,6 +10,7 @@ import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
+import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
@@ -96,7 +97,7 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomInfoRes joinRoom(Long roomId, Long userId, String inputPassword) {
+    public RoomUpdateResponse joinRoom(Long roomId, Long userId, String inputPassword) {
         Room room = roomRepository.findById(roomId).orElseThrow(() -> new ServiceException("404-2", "방을 찾을 수 없습니다."));
 
         // 비밀번호 체크 (방에 비밀번호가 걸려있는 경우만)
@@ -122,17 +123,28 @@ public class RoomService {
         participantRepository.save(participant);
         room.addParticipant(participant);
 
-        return getRoomDetail(roomId);
+        return RoomUpdateResponse.builder()
+                .roomId(roomId)
+                .type("USER_ENTER")
+                .participants(room.getParticipants().stream()
+                        .map(p -> p.getUserId().getNickname())
+                        .toList())
+                .message(user.getNickname() + "님이 입장하셨습니다.")
+                .build();
     }
 
     @Transactional
-    public void leaveRoom(Long roomId, Long userId) {
-        Room room = roomRepository.findById(roomId).orElseThrow(() -> new ServiceException("404-2", "방을 찾을 수 없습니다."));
+    public RoomUpdateResponse leaveRoom(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
 
         Participant participant = participantRepository
-                .findByRoomAndUserId(room, user)
+                .findByUserId(user)
                 .orElseThrow(() -> new ServiceException("404-3", "참여 정보를 찾을 수 없습니다."));
+
+        Room room = participant.getRoom();
+        Long roomId = room.getId();
+        Long leaverId = userId;
+        Long newHostId = null;
 
         // 방장이 나가는 경우 방장 위임 로직
         if (participant.isHost() && room.getCurPlayers() > 1) {
@@ -151,7 +163,19 @@ public class RoomService {
         // 방에 아무도 없으면 방 삭제
         if (room.getCurPlayers() == 0) {
             roomRepository.delete(room);
+            return null;
         }
+        // 웹소켓 동기화를 위한 데이터 반환
+        return RoomUpdateResponse.builder()
+                .roomId(roomId)
+                .type("USER_LEAVE")
+                .leaverId(leaverId)
+                .newHostId(newHostId != null ? newHostId : room.getHostId())
+                .participants(room.getParticipants().stream()
+                        .map(p -> p.getUserId().getNickname())
+                        .toList())
+                .message(user.getNickname() + "님이 퇴장하셨습니다.")
+                .build();
     }
 
     @Transactional

--- a/src/main/java/backend/drawrace/domain/round/dto/SubmitDrawingRequest.java
+++ b/src/main/java/backend/drawrace/domain/round/dto/SubmitDrawingRequest.java
@@ -3,11 +3,13 @@ package backend.drawrace.domain.round.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class SubmitDrawingRequest {
 
     @NotNull private Long participantId;

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -2,6 +2,7 @@ package backend.drawrace.domain.round.service;
 
 import java.util.List;
 
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +40,7 @@ public class RoundService {
     private final KeywordGenerator keywordGenerator;
     private final RoundValidator roundValidator;
     private final AiInferenceService aiInferenceService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     /**
      * 게임 시작 처리
@@ -65,7 +67,11 @@ public class RoundService {
         List<Participant> participants = participantRepository.findByRoomId(roomId);
         saveRoundParticipants(savedRound, participants);
 
-        return RoundStartResponse.from(savedRound);
+        RoundStartResponse response = RoundStartResponse.from(savedRound);
+
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
+
+        return response;
     }
 
     /**
@@ -122,7 +128,15 @@ public class RoundService {
         }
 
         // 전원 제출 완료 시 라운드 종료 처리
-        return handleRoundCompletion(round, aiResult, submittedCount, totalParticipantCount);
+        SubmitDrawingResponse response = handleRoundCompletion(round, aiResult, submittedCount, totalParticipantCount);
+
+        if (response.isRoundFinished()) {
+            Long roomId = round.getRoom().getId();
+            // 구독 경로: /sub/rooms/{roomId} 로 결과 전송
+            messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
+        }
+
+        return response;
     }
 
     /**

--- a/src/main/java/backend/drawrace/global/handler/WebSocketEventListener.java
+++ b/src/main/java/backend/drawrace/global/handler/WebSocketEventListener.java
@@ -1,0 +1,47 @@
+package backend.drawrace.global.handler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
+import backend.drawrace.domain.room.service.RoomService;
+import backend.drawrace.global.security.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final RoomService roomService;
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        // [인증] StompHandler에서 저장한 유저 정보 추출
+        if (headerAccessor.getUser() instanceof UsernamePasswordAuthenticationToken token) {
+            SecurityUser user = (SecurityUser) token.getPrincipal();
+            Long userId = user.getUserId();
+
+            log.info("웹소켓 연결 종료 감지: 유저 ID {}", userId);
+
+            // [실시간 동기화]
+            // 1. 기존 RoomService의 leaveRoom 호출 (DB 처리 및 방장 위임 로직 포함)
+            // 2. 그 결과로 생성된 RoomUpdateResponse를 받아옴
+            RoomUpdateResponse updateInfo = roomService.leaveRoom(userId);
+
+            if (updateInfo != null) {
+                // 3. 방에 남은 참여자들에게 바뀐 상태 실시간 전송
+                messagingTemplate.convertAndSend("/sub/rooms/" + updateInfo.getRoomId(), updateInfo);
+            }
+        }
+    }
+}

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
+import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
@@ -88,6 +89,34 @@ class RoomServiceTest {
     }
 
     @Test
+    @DisplayName("유저가 방을 나갈 때 실시간 업데이트 응답을 반환한다")
+    void leaveRoom_ReturnRoomUpdateResponse() {
+        Long userId = 1L;
+        User user = mock(User.class);
+        given(user.getNickname()).willReturn("채은");
+
+        Room room = mock(Room.class);
+        given(room.getId()).willReturn(10L);
+        doReturn((short) 2).when(room).getCurPlayers(); // 남은 인원이 있는 경우
+
+        Participant participant = mock(Participant.class);
+        given(participant.getRoom()).willReturn(room);
+        given(participant.isHost()).willReturn(false);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(participantRepository.findByUserId(user)).willReturn(Optional.of(participant));
+
+        RoomUpdateResponse response = roomService.leaveRoom(userId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getRoomId()).isEqualTo(10L);
+        assertThat(response.getType()).isEqualTo("USER_LEAVE");
+        assertThat(response.getMessage()).contains("채은님이 퇴장하셨습니다.");
+
+        verify(participantRepository, times(1)).delete(participant);
+    }
+
+    @Test
     @DisplayName("게임 종료 성공 - 우승자 마킹 및 스탯이 업데이트된다")
     void finishGame_success() throws Exception {
 
@@ -142,11 +171,10 @@ class RoomServiceTest {
         room.addParticipant(hostPart);
         room.addParticipant(nextPart);
 
-        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
         given(userRepository.findById(hostId)).willReturn(Optional.of(hostUser));
-        given(participantRepository.findByRoomAndUserId(room, hostUser)).willReturn(Optional.of(hostPart));
+        given(participantRepository.findByUserId(hostUser)).willReturn(Optional.of(hostPart));
 
-        roomService.leaveRoom(roomId, hostId);
+        roomService.leaveRoom(hostId);
 
         assertThat(room.getHostId()).isEqualTo(nextHostId);
         assertThat(nextPart.isHost()).isTrue();

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
@@ -36,7 +36,6 @@ import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.round.validator.RoundValidator;
 import backend.drawrace.domain.user.entity.User;
 import backend.drawrace.global.exception.ServiceException;
-
 
 @ExtendWith(MockitoExtension.class)
 class RoundServiceTest {

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
@@ -35,6 +36,7 @@ import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.round.validator.RoundValidator;
 import backend.drawrace.domain.user.entity.User;
 import backend.drawrace.global.exception.ServiceException;
+
 
 @ExtendWith(MockitoExtension.class)
 class RoundServiceTest {
@@ -59,6 +61,9 @@ class RoundServiceTest {
 
     @Mock
     private RoundValidator roundValidator;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
 
     @Mock
     private AiInferenceService aiInferenceService;

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
@@ -1,0 +1,116 @@
+package backend.drawrace.domain.round.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import backend.drawrace.domain.room.entity.Participant;
+import backend.drawrace.domain.room.entity.Room;
+import backend.drawrace.domain.room.repository.ParticipantRepository;
+import backend.drawrace.domain.room.service.RankingService;
+import backend.drawrace.domain.round.dto.AiInferenceResponse;
+import backend.drawrace.domain.round.dto.SubmitDrawingRequest;
+import backend.drawrace.domain.round.dto.SubmitDrawingResponse;
+import backend.drawrace.domain.round.entity.Round;
+import backend.drawrace.domain.round.entity.RoundSubmission;
+import backend.drawrace.domain.round.repository.RoundParticipantRepository;
+import backend.drawrace.domain.round.repository.RoundRepository;
+import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
+import backend.drawrace.domain.round.validator.RoundValidator;
+
+@ExtendWith(MockitoExtension.class)
+class RoundServiceWebSocketTest {
+
+    @InjectMocks
+    private RoundService roundService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RoundRepository roundRepository;
+
+    @Mock
+    private RoundValidator roundValidator;
+
+    @Mock
+    private RoundSubmissionRepository roundSubmissionRepository;
+
+    @Mock
+    private RoundParticipantRepository roundParticipantRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private KeywordGenerator keywordGenerator;
+
+    @Mock
+    private AiInferenceService aiInferenceService;
+
+    @Mock
+    private RankingService rankingService;
+
+    @Test
+    @DisplayName("라운드 종료 시 웹소켓으로 결과가 전송되는지 확인한다")
+    void shouldBroadcastWhenRoundFinished() {
+        // given
+        Long roundId = 1L;
+        Long userId = 1L;
+        Long roomId = 10L;
+        Long participantId = 100L;
+
+        Room room = mock(Room.class);
+        lenient().when(room.getId()).thenReturn(roomId);
+        lenient().when(room.getTotalRounds()).thenReturn((short) 3);
+
+        Round round = mock(Round.class);
+        lenient().when(round.getId()).thenReturn(roundId);
+        lenient().when(round.getRoom()).thenReturn(room);
+        lenient().when(round.getRoundNumber()).thenReturn(1);
+        lenient().when(roundRepository.findById(roundId)).thenReturn(Optional.of(round));
+
+        Participant participant = mock(Participant.class);
+        lenient().when(participant.getId()).thenReturn(participantId);
+        lenient()
+                .when(participantRepository.findByIdAndRoomId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(participant));
+
+        SubmitDrawingRequest request = new SubmitDrawingRequest(participantId, "image-data");
+
+        // [핵심] lenient()를 사용하여 불필요한 스터빙 예외를 방지함
+        lenient().when(keywordGenerator.generateKeyword()).thenReturn("강아지");
+        lenient().when(aiInferenceService.infer(anyString(), any())).thenReturn(new AiInferenceResponse("정답", 90.0));
+
+        // 전원 제출 상황 시뮬레이션
+        lenient().when(roundSubmissionRepository.countByRoundId(roundId)).thenReturn(1L);
+        lenient().when(roundParticipantRepository.countByRoundId(roundId)).thenReturn(1L);
+
+        Round nextRound = mock(Round.class);
+        lenient().when(nextRound.getId()).thenReturn(2L);
+        lenient().when(roundRepository.save(any(Round.class))).thenReturn(nextRound);
+
+        RoundSubmission submission = mock(RoundSubmission.class);
+        lenient().when(submission.getParticipant()).thenReturn(participant);
+        lenient().when(submission.getScore()).thenReturn(90.0);
+        lenient().when(roundSubmissionRepository.findByRoundId(roundId)).thenReturn(List.of(submission));
+
+        // when
+        roundService.submitDrawing(roundId, userId, request);
+
+        // then
+        // 실제로 웹소켓 발송이 일어났는지 검증
+        verify(messagingTemplate, times(1))
+                .convertAndSend(eq("/sub/rooms/" + roomId), any(SubmitDrawingResponse.class));
+    }
+}

--- a/src/test/java/backend/drawrace/global/handler/WebSocketEventListenerTest.java
+++ b/src/test/java/backend/drawrace/global/handler/WebSocketEventListenerTest.java
@@ -1,0 +1,56 @@
+package backend.drawrace.global.handler;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import backend.drawrace.domain.room.service.RoomService;
+import backend.drawrace.global.security.SecurityUser;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketEventListenerTest {
+
+    @InjectMocks
+    private WebSocketEventListener webSocketEventListener;
+
+    @Mock
+    private RoomService roomService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    @DisplayName("세션 종료 이벤트 발생 시 RoomService의 leaveRoom이 호출된다")
+    void handleDisconnect_ShouldInvokeLeaveRoom() {
+        // given
+        SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(securityUser, null);
+
+        // STOMP 헤더 설정
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+        accessor.setUser(auth);
+        accessor.setSessionId("session-123");
+
+        Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+        SessionDisconnectEvent event = new SessionDisconnectEvent(this, message, "session-123", CloseStatus.NORMAL);
+
+        // when
+        webSocketEventListener.handleWebSocketDisconnectListener(event);
+
+        // then
+        verify(roomService, times(1)).leaveRoom(1L);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 게임의 생명주기(입장-시작-종료-퇴장) 전 과정에 걸쳐 모든 참여자가 동일한 화면을 볼 수 있도록 실시간 상태 동기화 시스템을 구축함.
- 웹소켓 연결이 예기치 않게 끊기는 상황(탭 닫기 등)에서도 게임 데이터가 안전하게 업데이트되고 남은 참여자들에게 즉시 공유되도록 리스너를 구현함.

## 🔢 작업 단계
- [ ] RoundService 내 게임 시작(startGame) 및 라운드 종료(submitDrawing) 알림 연동
- [ ] RoomService 내 입장/퇴장 로직을 실시간 응답 규격(RoomUpdateResponse)에 맞게 고도화
- [ ] WebSocketEventListener를 통한 비정상 종료 대응 및 자동 퇴장 처리
- [ ] RoomController의 HTTP API 호출 시 실시간 브로드캐스팅 로직 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #25 