### PR TITLE
Feat: AI gateway fallback 및 판별 실패 처리 추가

### DIFF
--- a/src/main/java/backend/drawrace/domain/round/service/GatewayAiInferenceService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/GatewayAiInferenceService.java
@@ -17,7 +17,9 @@ import backend.drawrace.global.config.AiProperties;
 import backend.drawrace.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @ConditionalOnProperty(name = "ai.mode", havingValue = "gateway")
 @RequiredArgsConstructor
@@ -26,8 +28,31 @@ public class GatewayAiInferenceService implements AiInferenceService {
     private final AiProperties aiProperties;
     private final ObjectMapper objectMapper;
 
+    /**
+     * AI Gateway를 호출해 그림 판별을 수행한다.
+     * - 1차 실패 시 1회 재시도한다.
+     * - 최종 실패 시 예외를 던져 제출을 실패 처리한다.
+     */
     @Override
     public AiInferenceResponse infer(String imageData, String keyword) {
+        try {
+            return requestInference(imageData, keyword);
+        } catch (Exception first) {
+            log.warn("AI 판별 1차 실패. 재시도합니다. keyword={}", keyword, first);
+
+            try {
+                return requestInference(imageData, keyword);
+            } catch (Exception second) {
+                log.error("AI 판별 최종 실패. keyword={}", keyword, second);
+                throw new ServiceException("500-1", "AI 판별에 실패했습니다. 다시 시도해주세요.");
+            }
+        }
+    }
+
+    /**
+     * 실제 Gateway 요청과 응답 파싱을 수행한다.
+     */
+    private AiInferenceResponse requestInference(String imageData, String keyword) {
         RestClient restClient = RestClient.builder()
                 .baseUrl(aiProperties.baseUrl())
                 .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey())
@@ -52,10 +77,14 @@ public class GatewayAiInferenceService implements AiInferenceService {
 
         String content = sanitizeContent(extractContent(response));
         GatewayInferenceResult result = parseInferenceResult(content);
+        validateInferenceResult(result);
 
         return new AiInferenceResponse(result.getAiAnswer(), result.getScore());
     }
 
+    /**
+     * 그림 판별 AI의 역할과 출력 규칙을 지정한다.
+     */
     private String buildSystemPrompt() {
         return """
                 너는 그림 판별 AI다.
@@ -70,6 +99,9 @@ public class GatewayAiInferenceService implements AiInferenceService {
                 """;
     }
 
+    /**
+     * 판별 대상 그림과 정답 키워드 조건을 전달한다.
+     */
     private String buildUserPrompt(String keyword) {
         return """
                 사용자가 제출한 그림을 보고 무엇을 그렸는지 추론하라.
@@ -79,6 +111,9 @@ public class GatewayAiInferenceService implements AiInferenceService {
                 """.formatted(keyword);
     }
 
+    /**
+     * Gateway 응답에서 실제 content 문자열을 추출한다.
+     */
     private String extractContent(GatewayChatResponse response) {
         if (response == null
                 || response.getChoices() == null
@@ -91,6 +126,9 @@ public class GatewayAiInferenceService implements AiInferenceService {
         return response.getChoices().get(0).getMessage().getContent();
     }
 
+    /**
+     * AI 응답에서 코드블록이나 불필요한 텍스트를 제거해 JSON 본문만 남긴다.
+     */
     private String sanitizeContent(String content) {
         String cleaned = content.replace("```json", "").replace("```", "").trim();
 
@@ -104,11 +142,27 @@ public class GatewayAiInferenceService implements AiInferenceService {
         return cleaned;
     }
 
+    /**
+     * 정제된 JSON 문자열을 판별 결과 객체로 변환한다.
+     */
     private GatewayInferenceResult parseInferenceResult(String content) {
         try {
             return objectMapper.readValue(content, GatewayInferenceResult.class);
         } catch (JsonProcessingException e) {
             throw new ServiceException("500-1", "AI 응답 파싱에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 판별 결과의 필수 값과 score 범위를 검증한다.
+     */
+    private void validateInferenceResult(GatewayInferenceResult result) {
+        if (result == null
+                || result.getAiAnswer() == null
+                || result.getAiAnswer().isBlank()
+                || result.getScore() < 0.0
+                || result.getScore() > 1.0) {
+            throw new ServiceException("500-1", "AI 응답이 올바르지 않습니다.");
         }
     }
 }

--- a/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
+++ b/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
@@ -22,8 +22,7 @@ public class GatewayKeywordGenerator implements KeywordGenerator {
 
     private final AiProperties aiProperties;
 
-    private static final List<String> FALLBACK_KEYWORDS =
-            List.of("사과", "자동차", "고양이", "비행기", "의자");
+    private static final List<String> FALLBACK_KEYWORDS = List.of("사과", "자동차", "고양이", "비행기", "의자");
 
     /**
      * AI Gateway를 호출해 게임용 제시어를 생성한다.

--- a/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
+++ b/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
@@ -1,6 +1,7 @@
 package backend.drawrace.domain.round.service;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
@@ -9,10 +10,11 @@ import org.springframework.web.client.RestClient;
 import backend.drawrace.domain.round.dto.gateway.GatewayChatRequest;
 import backend.drawrace.domain.round.dto.gateway.GatewayChatResponse;
 import backend.drawrace.global.config.AiProperties;
-import backend.drawrace.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @ConditionalOnProperty(name = "ai.mode", havingValue = "gateway")
 @RequiredArgsConstructor
@@ -20,39 +22,49 @@ public class GatewayKeywordGenerator implements KeywordGenerator {
 
     private final AiProperties aiProperties;
 
+    private static final List<String> FALLBACK_KEYWORDS =
+            List.of("사과", "자동차", "고양이", "비행기", "의자");
+
     /**
      * AI Gateway를 호출해 게임용 제시어를 생성한다.
+     * 실패하거나 응답이 이상하면 fallback 키워드를 반환한다.
      */
     @Override
     public String generateKeyword() {
-        RestClient restClient = RestClient.builder()
-                .baseUrl(aiProperties.baseUrl())
-                .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey())
-                .build();
+        try {
+            RestClient restClient = RestClient.builder()
+                    .baseUrl(aiProperties.baseUrl())
+                    .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey())
+                    .build();
 
-        GatewayChatRequest request = GatewayChatRequest.builder()
-                .model(aiProperties.model())
-                .temperature(0.8)
-                .messages(List.of(
-                        GatewayChatRequest.systemMessage(buildSystemPrompt()),
-                        GatewayChatRequest.userMessage(buildUserPrompt())))
-                .build();
+            GatewayChatRequest request = GatewayChatRequest.builder()
+                    .model(aiProperties.model())
+                    .temperature(0.8)
+                    .messages(List.of(
+                            GatewayChatRequest.systemMessage(buildSystemPrompt()),
+                            GatewayChatRequest.userMessage(buildUserPrompt())))
+                    .build();
 
-        GatewayChatResponse response = restClient
-                .post()
-                .uri("/chat/completions")
-                .body(request)
-                .retrieve()
-                .body(GatewayChatResponse.class);
+            GatewayChatResponse response = restClient
+                    .post()
+                    .uri("/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(GatewayChatResponse.class);
 
-        String content = extractContent(response).trim();
-        String keyword = sanitizeKeyword(content);
+            String content = extractContent(response).trim();
+            String keyword = sanitizeKeyword(content);
 
-        if (keyword.isBlank()) {
-            throw new ServiceException("500-1", "AI 제시어 생성에 실패했습니다.");
+            if (keyword.isBlank()) {
+                log.warn("AI 제시어 응답이 비어 있어 fallback 키워드를 사용합니다. content={}", content);
+                return getFallbackKeyword();
+            }
+
+            return keyword;
+        } catch (Exception e) {
+            log.warn("AI 제시어 생성 실패로 fallback 키워드를 사용합니다.", e);
+            return getFallbackKeyword();
         }
-
-        return keyword;
     }
 
     /**
@@ -91,7 +103,7 @@ public class GatewayKeywordGenerator implements KeywordGenerator {
                 || response.getChoices().isEmpty()
                 || response.getChoices().get(0).getMessage() == null
                 || response.getChoices().get(0).getMessage().getContent() == null) {
-            throw new ServiceException("500-1", "AI 응답이 올바르지 않습니다.");
+            return "";
         }
         return response.getChoices().get(0).getMessage().getContent();
     }
@@ -117,5 +129,13 @@ public class GatewayKeywordGenerator implements KeywordGenerator {
         cleaned = cleaned.replaceAll("\\s+", "");
 
         return cleaned;
+    }
+
+    /**
+     * fallback 키워드 목록에서 랜덤으로 하나를 선택한다.
+     */
+    private String getFallbackKeyword() {
+        int index = ThreadLocalRandom.current().nextInt(FALLBACK_KEYWORDS.size());
+        return FALLBACK_KEYWORDS.get(index);
     }
 }

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -103,6 +103,8 @@ public class RoundService {
         roundValidator.validateNotSubmitted(alreadySubmitted);
 
         // AI 판독 수행
+        // - 내부적으로 1회 재시도
+        // - 최종 실패 시 예외를 던져 제출을 실패 처리한다
         AiInferenceResponse aiResult = aiInferenceService.infer(request.getImageData(), round.getKeyword());
 
         // 제출 기록 저장

--- a/src/test/java/backend/drawrace/domain/round/service/GatewayAiInferenceServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/GatewayAiInferenceServiceTest.java
@@ -16,96 +16,124 @@ import backend.drawrace.global.exception.ServiceException;
 
 class GatewayAiInferenceServiceTest {
 
-    private final GatewayAiInferenceService gatewayAiInferenceService = new GatewayAiInferenceService(
-            new AiProperties("https://test.example.com", "test-key", "test-model"), new ObjectMapper());
+    private final GatewayAiInferenceService gatewayAiInferenceService =
+            new GatewayAiInferenceService(
+                    new AiProperties("http://test", "test-key", "test-model"),
+                    new ObjectMapper());
 
     @Test
-    @DisplayName("sanitizeContent는 코드블록이 포함된 JSON 응답을 정제한다")
-    void sanitizeContent_success_codeBlockWrappedJson() throws Exception {
-        String rawContent = """
-            ```json
-            {
-              "aiAnswer": "사과",
-              "score": 0.0
-            }
-            ```
-            """;
-
-        String sanitized = invokeSanitizeContent(rawContent);
-
-        assertThat(sanitized).isEqualTo("""
-            {
-              "aiAnswer": "사과",
-              "score": 0.0
-            }""");
-    }
-
-    @Test
-    @DisplayName("sanitizeContent는 앞뒤 설명이 있어도 JSON 본문만 추출한다")
-    void sanitizeContent_success_extractJsonBody() throws Exception {
-        String rawContent = """
-            아래는 분석 결과입니다.
-            ```json
-            {
-              "aiAnswer": "사과",
-              "score": 0.82
-            }
-            ```
-            감사합니다.
-            """;
-
-        String sanitized = invokeSanitizeContent(rawContent);
-
-        assertThat(sanitized).isEqualTo("""
-            {
-              "aiAnswer": "사과",
-              "score": 0.82
-            }""");
-    }
-
-    @Test
-    @DisplayName("parseInferenceResult는 정상 JSON 문자열을 파싱한다")
-    void parseInferenceResult_success() throws Exception {
+    @DisplayName("코드블록으로 감싸진 JSON 응답에서 JSON 본문만 추출한다")
+    void sanitizeContent_codeBlockWrappedJson() throws Exception {
         String content = """
+                ```json
+                {
+                  "aiAnswer": "사과",
+                  "score": 0.82
+                }
+                ```
+                """;
+
+        String result = invokeSanitizeContent(content);
+
+        assertThat(result).isEqualTo("""
+                {
+                  "aiAnswer": "사과",
+                  "score": 0.82
+                }""");
+    }
+
+    @Test
+    @DisplayName("설명 문장이 섞여 있어도 JSON 본문만 추출한다")
+    void sanitizeContent_extractJsonBody() throws Exception {
+        String content = """
+                아래는 판별 결과입니다.
+
                 {
                   "aiAnswer": "사과",
                   "score": 0.91
                 }
                 """;
 
+        String result = invokeSanitizeContent(content);
+
+        assertThat(result).isEqualTo("""
+                {
+                  "aiAnswer": "사과",
+                  "score": 0.91
+                }""");
+    }
+
+    @Test
+    @DisplayName("정상 JSON 문자열을 판별 결과 객체로 변환한다")
+    void parseInferenceResult_success() throws Exception {
+        String content = """
+                {
+                  "aiAnswer": "사과",
+                  "score": 0.95
+                }
+                """;
+
         GatewayInferenceResult result = invokeParseInferenceResult(content);
 
         assertThat(result.getAiAnswer()).isEqualTo("사과");
-        assertThat(result.getScore()).isEqualTo(0.91);
+        assertThat(result.getScore()).isEqualTo(0.95);
     }
 
     @Test
-    @DisplayName("sanitizeContent 후 parseInferenceResult는 코드블록 응답을 정상 파싱한다")
-    void sanitizeAndParse_success() throws Exception {
-        String rawContent = """
-                ```json
-                {
-                  "aiAnswer": "사과",
-                  "score": 0.77
-                }
-                ```
-                """;
-
-        String sanitized = invokeSanitizeContent(rawContent);
-        GatewayInferenceResult result = invokeParseInferenceResult(sanitized);
-
-        assertThat(result.getAiAnswer()).isEqualTo("사과");
-        assertThat(result.getScore()).isEqualTo(0.77);
-    }
-
-    @Test
-    @DisplayName("parseInferenceResult는 JSON 형식이 아니면 예외를 던진다")
+    @DisplayName("JSON 형식이 아니면 파싱 예외가 발생한다")
     void parseInferenceResult_fail_invalidJson() {
-        String invalidContent = "사과입니다. score는 0.9입니다.";
+        String content = "사과입니다. score는 0.9입니다.";
 
-        assertThatThrownBy(() -> invokeParseInferenceResult(invalidContent))
+        assertThatThrownBy(() -> invokeParseInferenceResult(content))
                 .isInstanceOf(ServiceException.class)
                 .hasMessageContaining("AI 응답 파싱에 실패했습니다");
+    }
+
+    @Test
+    @DisplayName("aiAnswer와 score가 정상 범위면 검증을 통과한다")
+    void validateInferenceResult_success() throws Exception {
+        GatewayInferenceResult result = new GatewayInferenceResult();
+        setField(result, "aiAnswer", "사과");
+        setField(result, "score", 0.77);
+
+        assertThatCode(() -> invokeValidateInferenceResult(result))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("aiAnswer가 비어 있으면 검증 예외가 발생한다")
+    void validateInferenceResult_fail_blankAnswer() throws Exception {
+        GatewayInferenceResult result = new GatewayInferenceResult();
+        setField(result, "aiAnswer", "");
+        setField(result, "score", 0.77);
+
+        assertThatThrownBy(() -> invokeValidateInferenceResult(result))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("AI 응답이 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("score가 0 미만이면 검증 예외가 발생한다")
+    void validateInferenceResult_fail_negativeScore() throws Exception {
+        GatewayInferenceResult result = new GatewayInferenceResult();
+        setField(result, "aiAnswer", "사과");
+        setField(result, "score", -0.1);
+
+        assertThatThrownBy(() -> invokeValidateInferenceResult(result))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("AI 응답이 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("score가 1 초과면 검증 예외가 발생한다")
+    void validateInferenceResult_fail_scoreOverOne() throws Exception {
+        GatewayInferenceResult result = new GatewayInferenceResult();
+        setField(result, "aiAnswer", "사과");
+        setField(result, "score", 1.1);
+
+        assertThatThrownBy(() -> invokeValidateInferenceResult(result))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("AI 응답이 올바르지 않습니다");
     }
 
     @Test
@@ -125,7 +153,15 @@ class GatewayAiInferenceServiceTest {
     }
 
     @Test
-    @DisplayName("extractContent는 choices가 없으면 예외를 던진다")
+    @DisplayName("응답이 null이면 content 추출 예외가 발생한다")
+    void extractContent_fail_nullResponse() {
+        assertThatThrownBy(() -> invokeExtractContent(null))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("AI 응답이 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("choices가 없으면 content 추출 예외가 발생한다")
     void extractContent_fail_emptyChoices() {
         GatewayChatResponse response = new GatewayChatResponse();
 
@@ -154,8 +190,26 @@ class GatewayAiInferenceServiceTest {
         }
     }
 
+    private void invokeValidateInferenceResult(GatewayInferenceResult result) throws Exception {
+        Method method = GatewayAiInferenceService.class.getDeclaredMethod(
+                "validateInferenceResult",
+                GatewayInferenceResult.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(gatewayAiInferenceService, result);
+        } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw e;
+        }
+    }
+
     private String invokeExtractContent(GatewayChatResponse response) throws Exception {
-        Method method = GatewayAiInferenceService.class.getDeclaredMethod("extractContent", GatewayChatResponse.class);
+        Method method = GatewayAiInferenceService.class.getDeclaredMethod(
+                "extractContent",
+                GatewayChatResponse.class);
         method.setAccessible(true);
 
         try {

--- a/src/test/java/backend/drawrace/domain/round/service/GatewayAiInferenceServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/GatewayAiInferenceServiceTest.java
@@ -16,10 +16,8 @@ import backend.drawrace.global.exception.ServiceException;
 
 class GatewayAiInferenceServiceTest {
 
-    private final GatewayAiInferenceService gatewayAiInferenceService =
-            new GatewayAiInferenceService(
-                    new AiProperties("http://test", "test-key", "test-model"),
-                    new ObjectMapper());
+    private final GatewayAiInferenceService gatewayAiInferenceService = new GatewayAiInferenceService(
+            new AiProperties("http://test", "test-key", "test-model"), new ObjectMapper());
 
     @Test
     @DisplayName("코드블록으로 감싸진 JSON 응답에서 JSON 본문만 추출한다")
@@ -96,8 +94,7 @@ class GatewayAiInferenceServiceTest {
         setField(result, "aiAnswer", "사과");
         setField(result, "score", 0.77);
 
-        assertThatCode(() -> invokeValidateInferenceResult(result))
-                .doesNotThrowAnyException();
+        assertThatCode(() -> invokeValidateInferenceResult(result)).doesNotThrowAnyException();
     }
 
     @Test
@@ -192,8 +189,7 @@ class GatewayAiInferenceServiceTest {
 
     private void invokeValidateInferenceResult(GatewayInferenceResult result) throws Exception {
         Method method = GatewayAiInferenceService.class.getDeclaredMethod(
-                "validateInferenceResult",
-                GatewayInferenceResult.class);
+                "validateInferenceResult", GatewayInferenceResult.class);
         method.setAccessible(true);
 
         try {
@@ -207,9 +203,7 @@ class GatewayAiInferenceServiceTest {
     }
 
     private String invokeExtractContent(GatewayChatResponse response) throws Exception {
-        Method method = GatewayAiInferenceService.class.getDeclaredMethod(
-                "extractContent",
-                GatewayChatResponse.class);
+        Method method = GatewayAiInferenceService.class.getDeclaredMethod("extractContent", GatewayChatResponse.class);
         method.setAccessible(true);
 
         try {

--- a/src/test/java/backend/drawrace/domain/round/service/GatewayKeywordGeneratorTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/GatewayKeywordGeneratorTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import backend.drawrace.global.config.AiProperties;
-import backend.drawrace.global.exception.ServiceException;
 
 class GatewayKeywordGeneratorTest {
 
@@ -83,12 +82,11 @@ class GatewayKeywordGeneratorTest {
     }
 
     @Test
-    @DisplayName("응답이 null이면 예외가 발생한다")
-    void extractContent_nullResponse() {
-        assertThatThrownBy(() -> invokeExtractContent(null))
-                .rootCause()
-                .isInstanceOf(ServiceException.class)
-                .hasMessageContaining("AI 응답이 올바르지 않습니다");
+    @DisplayName("응답이 null이면 빈 문자열을 반환한다")
+    void extractContent_nullResponse_returnsEmptyString() throws Exception {
+        String result = invokeExtractContent(null);
+
+        assertThat(result).isEmpty();
     }
 
     private String invokeSanitizeKeyword(String content) throws Exception {


### PR DESCRIPTION
## 작업 내용
- AI 제시어 생성 실패 시 fallback 키워드를 반환하도록 보강했습니다.
- AI 그림 판별 실패 시 1회 재시도 후 최종 실패하면 제출 실패로 처리하도록 변경했습니다.
- AI 응답 유효성 검증 로직을 추가했습니다.
- 관련 테스트 코드를 수정 및 보강했습니다.

## 주요 변경 사항
- `GatewayKeywordGenerator`
  - fallback 키워드 처리 추가
- `GatewayAiInferenceService`
  - 1회 재시도 로직 추가
  - 응답 검증 로직 추가
  - 최종 실패 시 사용자 친화적 예외 메시지 반환
- 테스트 코드 보강
  - `GatewayKeywordGeneratorTest`
  - `GatewayAiInferenceServiceTest`

## 테스트
- [x] GatewayKeywordGeneratorTest
- [x] GatewayAiInferenceServiceTest
- [x] RoundServiceTest