### PR TITLE
[Feat] 실시간 채팅 및 게임 중계 시스템 구현

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
+++ b/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
@@ -1,0 +1,24 @@
+package backend.drawrace.domain.chat.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/rooms/{roomId}/chat")
+    public void sendChatMessage(@DestinationVariable Long roomId, ChatMessageDto chatMessage) {
+        // 일반 채팅은 TALK 타입으로 고정하여 브로드캐스팅
+        chatMessage.setType(ChatMessageDto.MessageType.TALK);
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);
+    }
+}

--- a/src/main/java/backend/drawrace/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/backend/drawrace/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,22 @@
+package backend.drawrace.domain.chat.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageDto {
+
+    public enum MessageType {
+        TALK, // 일반 채팅
+        NOTICE, // 시스템 알림 - 입장, 퇴장, 시작, 위임
+        WINNER // 시스템 알림 - 우승자 공지
+    }
+
+    private MessageType type;
+    private Long roomId;
+    private String sender; // 보낸 사람 닉네임 (시스템 메시지는 "System")
+    private String message;
+}

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -3,9 +3,11 @@ package backend.drawrace.domain.room.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
@@ -30,6 +32,7 @@ public class RoomService {
     private final ParticipantRepository participantRepository;
     private final UserRepository userRepository;
     private final RankingService rankingService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @Transactional
     public RoomInfoRes createRoom(CreateRoomReq req, Long userId) {
@@ -123,6 +126,14 @@ public class RoomService {
         participantRepository.save(participant);
         room.addParticipant(participant);
 
+        ChatMessageDto enterNotice = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.NOTICE)
+                .roomId(roomId)
+                .sender("System")
+                .message(user.getNickname() + "님이 입장하셨습니다.")
+                .build();
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", enterNotice);
+
         return RoomUpdateResponse.builder()
                 .roomId(roomId)
                 .type("USER_ENTER")
@@ -145,6 +156,7 @@ public class RoomService {
         Long roomId = room.getId();
         Long leaverId = userId;
         Long newHostId = null;
+        String nextHostNickname = "";
 
         // 방장이 나가는 경우 방장 위임 로직
         if (participant.isHost() && room.getCurPlayers() > 1) {
@@ -155,7 +167,29 @@ public class RoomService {
 
             nextHost.makeHost();
             room.changeHost(nextHost.getUserId().getId());
+
+            newHostId = nextHost.getUserId().getId();
+            nextHostNickname = nextHost.getUserId().getNickname();
         }
+
+        if (newHostId != null) {
+            ChatMessageDto hostNotice = ChatMessageDto.builder()
+                    .type(ChatMessageDto.MessageType.NOTICE)
+                    .roomId(roomId)
+                    .sender("System")
+                    .message("방장이 " + nextHostNickname + "님으로 변경되었습니다.")
+                    .build();
+            messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", hostNotice);
+        }
+
+        ChatMessageDto leaveNotice = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.NOTICE)
+                .roomId(roomId)
+                .sender("System")
+                .message(user.getNickname() + "님이 퇴장하셨습니다.")
+                .build();
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", leaveNotice);
+
         // 참여자 제거 및 인원 감소
         room.removeParticipant(participant);
         participantRepository.delete(participant);

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -6,6 +6,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
@@ -68,6 +69,14 @@ public class RoundService {
         saveRoundParticipants(savedRound, participants);
 
         RoundStartResponse response = RoundStartResponse.from(savedRound);
+
+        ChatMessageDto startNotice = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.NOTICE)
+                .roomId(roomId)
+                .sender("System")
+                .message("게임이 시작되었습니다! 주제에 맞춰 그림을 그려주세요.")
+                .build();
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", startNotice);
 
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
 
@@ -197,6 +206,18 @@ public class RoundService {
         roundWinner.increaseRoundWinCount();
         round.finish();
 
+        Long roomId = round.getRoom().getId();
+        String winnerNickname = roundWinner.getUserId().getNickname();
+
+        // [시스템 메시지 발송] 라운드 승리자 공지
+        ChatMessageDto winnerNotice = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.WINNER)
+                .roomId(roomId)
+                .sender("System")
+                .message("라운드 승리자: " + winnerNickname + "님! 축하합니다.")
+                .build();
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", winnerNotice);
+
         return handleAfterRoundFinished(round, aiResult, submittedCount, totalParticipantCount, roundWinner);
     }
 
@@ -219,6 +240,8 @@ public class RoundService {
         if (round.isTiebreaker()) {
             roundWinner.markWinner();
             room.finishGame();
+
+            sendFinalWinnerNotice(room.getId(), roundWinner.getUserId().getNickname());
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
@@ -281,6 +304,8 @@ public class RoundService {
             Participant finalWinner = topScorers.get(0);
             finalWinner.markWinner();
             room.finishGame();
+
+            sendFinalWinnerNotice(room.getId(), finalWinner.getUserId().getNickname());
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
@@ -365,5 +390,15 @@ public class RoundService {
         return participants.stream()
                 .filter(participant -> participant.getRoundWinCount() == maxWinCount)
                 .toList();
+    }
+
+    private void sendFinalWinnerNotice(Long roomId, String nickname) {
+        ChatMessageDto finalWinnerNotice = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.WINNER)
+                .roomId(roomId)
+                .sender("System")
+                .message("🎉 축하합니다! 최종 우승자는 " + nickname + "님입니다! 🎉")
+                .build();
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", finalWinnerNotice);
     }
 }

--- a/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
@@ -1,0 +1,45 @@
+package backend.drawrace.domain.chat.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
+
+@ExtendWith(MockitoExtension.class)
+class ChatControllerTest {
+
+    @InjectMocks
+    private ChatController chatController;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    @DisplayName("사용자가 채팅을 보내면 TALK 타입으로 브로드캐스팅된다")
+    void shouldSendChatMessageAsTalkType() {
+        Long roomId = 1L;
+        ChatMessageDto requestDto = ChatMessageDto.builder()
+                .roomId(roomId)
+                .sender("유저A")
+                .message("안녕하세요!")
+                .build();
+
+        chatController.sendChatMessage(roomId, requestDto);
+
+        // 정확한 경로(/sub/rooms/{roomId}/chat)로 메시지가 가는지 확인
+        // 메시지 타입이 TALK로 설정되었는지 확인
+        verify(messagingTemplate, times(1))
+                .convertAndSend(
+                        eq("/sub/rooms/" + roomId + "/chat"),
+                        argThat((ChatMessageDto dto) -> dto.getType() == ChatMessageDto.MessageType.TALK
+                                && dto.getMessage().equals("안녕하세요!")));
+    }
+}

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -17,7 +17,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
 import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
@@ -44,6 +46,9 @@ class RoomServiceTest {
 
     @Mock
     private RankingService rankingService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
 
     @InjectMocks
     private RoomService roomService;
@@ -93,7 +98,7 @@ class RoomServiceTest {
     void leaveRoom_ReturnRoomUpdateResponse() {
         Long userId = 1L;
         User user = mock(User.class);
-        given(user.getNickname()).willReturn("채은");
+        given(user.getNickname()).willReturn("유저A");
 
         Room room = mock(Room.class);
         given(room.getId()).willReturn(10L);
@@ -111,7 +116,7 @@ class RoomServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.getRoomId()).isEqualTo(10L);
         assertThat(response.getType()).isEqualTo("USER_LEAVE");
-        assertThat(response.getMessage()).contains("채은님이 퇴장하셨습니다.");
+        assertThat(response.getMessage()).contains("유저A님이 퇴장하셨습니다.");
 
         verify(participantRepository, times(1)).delete(participant);
     }
@@ -179,6 +184,52 @@ class RoomServiceTest {
         assertThat(room.getHostId()).isEqualTo(nextHostId);
         assertThat(nextPart.isHost()).isTrue();
         verify(participantRepository).delete(hostPart);
+    }
+
+    @Test
+    @DisplayName("유저 퇴장 시 퇴장 알림과 방장 위임 알림이 채팅창에 전달된다")
+    void leaveRoom_ShouldSendSystemNotice() {
+        // 1. Given: 테스트에 필요한 가짜 객체(Mock) 설정
+        Long userId = 1L;
+        Long roomId = 10L;
+
+        User user = mock(User.class);
+        lenient().when(user.getId()).thenReturn(userId);
+        lenient().when(user.getNickname()).thenReturn("유저A");
+
+        Room room = mock(Room.class);
+        lenient().when(room.getId()).thenReturn(roomId);
+        lenient().when(room.getCurPlayers()).thenReturn((short) 2); // 2명 있는 방
+
+        Participant participant = mock(Participant.class);
+        lenient().when(participant.getRoom()).thenReturn(room);
+        lenient().when(participant.isHost()).thenReturn(true); // 방장이 나가는 상황 가정
+        lenient().when(participant.getUserId()).thenReturn(user);
+
+        // 다음 방장이 될 사람 설정
+        Participant nextHost = mock(Participant.class);
+        User nextUser = mock(User.class);
+        lenient().when(nextUser.getNickname()).thenReturn("다음방장");
+        lenient().when(nextHost.getUserId()).thenReturn(nextUser);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(participantRepository.findByUserId(user)).willReturn(Optional.of(participant));
+
+        lenient().when(room.getParticipants()).thenReturn(List.of(participant, nextHost));
+
+        roomService.leaveRoom(userId);
+
+        verify(messagingTemplate, atLeastOnce())
+                .convertAndSend(
+                        eq("/sub/rooms/" + roomId + "/chat"),
+                        argThat((ChatMessageDto dto) -> dto.getType() == ChatMessageDto.MessageType.NOTICE
+                                && dto.getMessage().contains("유저A님이 퇴장하셨습니다.")));
+
+        verify(messagingTemplate, atLeastOnce())
+                .convertAndSend(
+                        eq("/sub/rooms/" + roomId + "/chat"),
+                        argThat((ChatMessageDto dto) -> dto.getType() == ChatMessageDto.MessageType.NOTICE
+                                && dto.getMessage().contains("방장이 다음방장님으로 변경되었습니다.")));
     }
 
     private Room createRoom(Long id, String title, Long hostId) throws Exception {

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
@@ -27,6 +28,7 @@ import backend.drawrace.domain.round.repository.RoundParticipantRepository;
 import backend.drawrace.domain.round.repository.RoundRepository;
 import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.round.validator.RoundValidator;
+import backend.drawrace.domain.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
 class RoundServiceWebSocketTest {
@@ -64,7 +66,6 @@ class RoundServiceWebSocketTest {
     @Test
     @DisplayName("라운드 종료 시 웹소켓으로 결과가 전송되는지 확인한다")
     void shouldBroadcastWhenRoundFinished() {
-        // given
         Long roundId = 1L;
         Long userId = 1L;
         Long roomId = 10L;
@@ -86,9 +87,12 @@ class RoundServiceWebSocketTest {
                 .when(participantRepository.findByIdAndRoomId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(participant));
 
+        User user = mock(User.class);
+        lenient().when(user.getNickname()).thenReturn("테스트유저");
+        lenient().when(participant.getUserId()).thenReturn(user);
+
         SubmitDrawingRequest request = new SubmitDrawingRequest(participantId, "image-data");
 
-        // [핵심] lenient()를 사용하여 불필요한 스터빙 예외를 방지함
         lenient().when(keywordGenerator.generateKeyword()).thenReturn("강아지");
         lenient().when(aiInferenceService.infer(anyString(), any())).thenReturn(new AiInferenceResponse("정답", 90.0));
 
@@ -105,12 +109,69 @@ class RoundServiceWebSocketTest {
         lenient().when(submission.getScore()).thenReturn(90.0);
         lenient().when(roundSubmissionRepository.findByRoundId(roundId)).thenReturn(List.of(submission));
 
-        // when
         roundService.submitDrawing(roundId, userId, request);
 
-        // then
         // 실제로 웹소켓 발송이 일어났는지 검증
         verify(messagingTemplate, times(1))
                 .convertAndSend(eq("/sub/rooms/" + roomId), any(SubmitDrawingResponse.class));
+    }
+
+    @Test
+    @DisplayName("라운드 종료 시 승리자 공지가 채팅창으로 발송된다")
+    void shouldSendWinnerNoticeWhenRoundFinished() {
+        // 1. Given: 라운드 종료 상황 세팅
+        Long roundId = 1L;
+        Long userId = 1L;
+        Long roomId = 10L;
+        Long participantId = 100L;
+
+        Room room = mock(Room.class);
+        lenient().when(room.getId()).thenReturn(roomId);
+        lenient().when(room.getTotalRounds()).thenReturn((short) 3);
+
+        Round round = mock(Round.class);
+        lenient().when(round.getId()).thenReturn(roundId);
+        lenient().when(round.getRoom()).thenReturn(room);
+        lenient().when(roundRepository.findById(roundId)).thenReturn(Optional.of(round));
+
+        Participant participant = mock(Participant.class);
+        User user = mock(User.class);
+        lenient().when(user.getNickname()).thenReturn("승리자유저A");
+        lenient().when(participant.getUserId()).thenReturn(user);
+        lenient()
+                .when(participantRepository.findByIdAndRoomId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(participant));
+
+        SubmitDrawingRequest request = new SubmitDrawingRequest(participantId, "image-data");
+
+        // 전원 제출 완료 상황 모킹
+        given(roundSubmissionRepository.countByRoundId(roundId)).willReturn(1L);
+        given(roundParticipantRepository.countByRoundId(roundId)).willReturn(1L);
+
+        // 승자 선정을 위한 가짜 제출 기록
+        RoundSubmission submission = mock(RoundSubmission.class);
+        lenient().when(submission.getParticipant()).thenReturn(participant);
+        lenient().when(submission.getScore()).thenReturn(95.0); // 여기가 152번 줄일 거야!
+        lenient().when(roundSubmissionRepository.findByRoundId(roundId)).thenReturn(List.of(submission));
+
+        // AI가 정답을 맞힌 상황
+        given(aiInferenceService.infer(anyString(), any())).willReturn(new AiInferenceResponse("정답", 95.0));
+
+        // 다음 라운드 생성을 위한 모킹 (NPE 방지)
+        Round nextRound = mock(Round.class);
+        lenient().when(nextRound.getId()).thenReturn(2L);
+        lenient().when(roundRepository.save(any())).thenReturn(nextRound);
+        lenient().when(keywordGenerator.generateKeyword()).thenReturn("사과");
+
+        // 그림 제출 (이 호출이 라운드 종료를 트리거함)
+        roundService.submitDrawing(roundId, userId, request);
+
+        //  검증
+        // [검증] /chat 채널로 WINNER 타입의 메시지가 갔는가?
+        verify(messagingTemplate, atLeastOnce())
+                .convertAndSend(
+                        eq("/sub/rooms/" + roomId + "/chat"),
+                        argThat((ChatMessageDto dto) -> dto.getType() == ChatMessageDto.MessageType.WINNER
+                                && dto.getMessage().contains("라운드 승리자: 승리자유저A님!")));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- WebSocket(STOMP)을 활용한 실시간 채팅 기능 구현 및 게임 내 주요 이벤트 중계 시스템 구축
- 일반 채팅(TALK)과 시스템 알림(NOTICE), 승리자 공지(WINNER) 타입을 분리
- 입/퇴장, 방장 위임, 게임 시작, 라운드 승리자, 최종 우승자 알림 로직 연동

## 🔢 작업 단계
- [ ] ChatMessageDto 설계 및 타입 정의
- [ ] ChatController 일반 채팅 브로드캐스팅 로직 구현
- [ ] RoomService 내 유저 상태 변화(입장/퇴장/위임) 공지 메시지 추가
- [ ] RoundService 내 게임 진행 상황(시작/승리자) 공지 메시지 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #32