### PR TITLE
[Feature] AI 유저의 게임 참여 기능

### DIFF
--- a/src/main/java/backend/drawrace/domain/room/controller/RoomController.java
+++ b/src/main/java/backend/drawrace/domain/room/controller/RoomController.java
@@ -97,4 +97,12 @@ public class RoomController {
         RoomInfoRes res = roomService.addAiParticipant(roomId, securityUser.getUserId());
         return new RsData<>("200-6", "AI 참가자를 추가했습니다.", res);
     }
+
+    @DeleteMapping("/{roomId}/ai-participants")
+    public RsData<RoomInfoRes> removeAiParticipant(
+            @PathVariable Long roomId, @AuthenticationPrincipal SecurityUser securityUser) {
+
+        RoomInfoRes res = roomService.removeAiParticipant(roomId, securityUser.getUserId());
+        return new RsData<>("200-7", "AI 참가자를 제거했습니다.", res);
+    }
 }

--- a/src/main/java/backend/drawrace/domain/room/dto/response/RoomInfoRes.java
+++ b/src/main/java/backend/drawrace/domain/room/dto/response/RoomInfoRes.java
@@ -11,5 +11,5 @@ public record RoomInfoRes(
         Long hostId,
         boolean isPlaying,
         List<ParticipantDto> participants) {
-    public record ParticipantDto(Long userId, String nickname, boolean isHost) {}
+    public record ParticipantDto(Long userId, String nickname, boolean isHost, boolean isAi) {}
 }

--- a/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
@@ -24,4 +24,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     Optional<Participant> findByUserId(User user);
 
     boolean existsByRoomIdAndUserId_Id(Long roomId, Long userId);
+
+    Optional<Participant> findByRoomIdAndUserId_Id(Long roomId, Long userId);
 }

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -85,7 +85,7 @@ public class RoomService {
 
         List<RoomInfoRes.ParticipantDto> participantDtos = room.getParticipants().stream()
                 .map(p -> new RoomInfoRes.ParticipantDto(
-                        p.getUserId().getId(), p.getUserId().getNickname(), p.isHost()))
+                        p.getUserId().getId(), p.getUserId().getNickname(), p.isHost(), p.getUserId().isAi()))
                 .toList();
 
         return new RoomInfoRes(

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -1,6 +1,7 @@
 package backend.drawrace.domain.room.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -194,11 +195,19 @@ public class RoomService {
 
         // 방장이 나가는 경우 방장 위임 로직 (AI는 방장이 될 수 없음)
         if (participant.isHost() && room.getCurPlayers() > 1) {
-            Participant nextHost = room.getParticipants().stream()
+            Optional<Participant> nextHostOpt = room.getParticipants().stream()
                     .filter(p -> !p.equals(participant) && !p.getUserId().isAi())
-                    .findFirst()
-                    .orElseThrow(() -> new ServiceException("500-2", "다음 방장을 찾을 수 없습니다."));
+                    .findFirst();
 
+            if (nextHostOpt.isEmpty()) {
+                // 남은 참여자가 AI뿐 → 방 삭제
+                room.removeParticipant(participant);
+                participantRepository.delete(participant);
+                roomRepository.delete(room);
+                return null;
+            }
+
+            Participant nextHost = nextHostOpt.get();
             nextHost.makeHost();
             room.changeHost(nextHost.getUserId().getId());
 
@@ -228,8 +237,9 @@ public class RoomService {
         room.removeParticipant(participant);
         participantRepository.delete(participant);
 
-        // 방에 아무도 없으면 방 삭제
-        if (room.getCurPlayers() == 0) {
+        // 방에 아무도 없거나 AI만 남으면 방 삭제
+        boolean onlyAiOrEmpty = room.getParticipants().stream().allMatch(p -> p.getUserId().isAi());
+        if (room.getCurPlayers() == 0 || onlyAiOrEmpty) {
             roomRepository.delete(room);
             return null;
         }
@@ -244,6 +254,25 @@ public class RoomService {
                         .toList())
                 .message(user.getNickname() + "님이 퇴장하셨습니다.")
                 .build();
+    }
+
+    @Transactional
+    public RoomInfoRes removeAiParticipant(Long roomId, Long hostId) {
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new ServiceException("404-2", "방을 찾을 수 없습니다."));
+
+        if (!room.getHostId().equals(hostId)) {
+            throw new ServiceException("403-1", "방장만 AI를 제거할 수 있습니다.");
+        }
+
+        User aiUser = userRepository.findByIsAi(true).orElseThrow(() -> new ServiceException("404-1", "AI 유저를 찾을 수 없습니다."));
+
+        Participant aiParticipant = participantRepository.findByRoomIdAndUserId_Id(roomId, aiUser.getId())
+                .orElseThrow(() -> new ServiceException("404-3", "AI가 방에 참여 중이지 않습니다."));
+
+        room.removeParticipant(aiParticipant);
+        participantRepository.delete(aiParticipant);
+
+        return getRoomDetail(roomId);
     }
 
     @Transactional

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -164,6 +164,11 @@ public class RoomService {
         User aiUser =
                 userRepository.findByIsAi(true).orElseThrow(() -> new ServiceException("404-1", "AI 유저를 찾을 수 없습니다."));
 
+        boolean alreadyInRoom = participantRepository.existsByRoomIdAndUserId_Id(roomId, aiUser.getId());
+        if (alreadyInRoom) {
+            throw new ServiceException("400-5", "AI는 이미 방에 참여 중입니다.");
+        }
+
         Participant aiParticipant =
                 Participant.builder().userId(aiUser).room(room).isHost(false).build();
 
@@ -187,10 +192,10 @@ public class RoomService {
         Long newHostId = null;
         String nextHostNickname = "";
 
-        // 방장이 나가는 경우 방장 위임 로직
+        // 방장이 나가는 경우 방장 위임 로직 (AI는 방장이 될 수 없음)
         if (participant.isHost() && room.getCurPlayers() > 1) {
             Participant nextHost = room.getParticipants().stream()
-                    .filter(p -> !p.equals(participant))
+                    .filter(p -> !p.equals(participant) && !p.getUserId().isAi())
                     .findFirst()
                     .orElseThrow(() -> new ServiceException("500-2", "다음 방장을 찾을 수 없습니다."));
 
@@ -259,6 +264,8 @@ public class RoomService {
                 .orElse(0);
 
         for (Participant p : participants) {
+            if (p.getUserId().isAi()) continue; // AI는 통계 기록 제외
+
             // 모든 참가자 전체 판수 기록
             p.getUserId().getStats().recordGame();
 

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -86,7 +86,10 @@ public class RoomService {
 
         List<RoomInfoRes.ParticipantDto> participantDtos = room.getParticipants().stream()
                 .map(p -> new RoomInfoRes.ParticipantDto(
-                        p.getUserId().getId(), p.getUserId().getNickname(), p.isHost(), p.getUserId().isAi()))
+                        p.getUserId().getId(),
+                        p.getUserId().getNickname(),
+                        p.isHost(),
+                        p.getUserId().isAi()))
                 .toList();
 
         return new RoomInfoRes(
@@ -238,7 +241,8 @@ public class RoomService {
         participantRepository.delete(participant);
 
         // 방에 아무도 없거나 AI만 남으면 방 삭제
-        boolean onlyAiOrEmpty = room.getParticipants().stream().allMatch(p -> p.getUserId().isAi());
+        boolean onlyAiOrEmpty =
+                room.getParticipants().stream().allMatch(p -> p.getUserId().isAi());
         if (room.getCurPlayers() == 0 || onlyAiOrEmpty) {
             roomRepository.delete(room);
             return null;
@@ -268,9 +272,11 @@ public class RoomService {
             throw new ServiceException("400-2", "이미 게임이 시작된 방입니다.");
         }
 
-        User aiUser = userRepository.findByIsAi(true).orElseThrow(() -> new ServiceException("404-1", "AI 유저를 찾을 수 없습니다."));
+        User aiUser =
+                userRepository.findByIsAi(true).orElseThrow(() -> new ServiceException("404-1", "AI 유저를 찾을 수 없습니다."));
 
-        Participant aiParticipant = participantRepository.findByRoomIdAndUserId_Id(roomId, aiUser.getId())
+        Participant aiParticipant = participantRepository
+                .findByRoomIdAndUserId_Id(roomId, aiUser.getId())
                 .orElseThrow(() -> new ServiceException("404-3", "AI가 방에 참여 중이지 않습니다."));
 
         room.removeParticipant(aiParticipant);

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -264,6 +264,10 @@ public class RoomService {
             throw new ServiceException("403-1", "방장만 AI를 제거할 수 있습니다.");
         }
 
+        if (room.isPlaying()) {
+            throw new ServiceException("400-2", "이미 게임이 시작된 방입니다.");
+        }
+
         User aiUser = userRepository.findByIsAi(true).orElseThrow(() -> new ServiceException("404-1", "AI 유저를 찾을 수 없습니다."));
 
         Participant aiParticipant = participantRepository.findByRoomIdAndUserId_Id(roomId, aiUser.getId())

--- a/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
@@ -1,0 +1,56 @@
+package backend.drawrace.domain.round.service;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import backend.drawrace.domain.round.dto.DrawingData;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "ai.mode", havingValue = "quickdraw")
+public class AiSubmissionService {
+
+    private static final double AI_SCORE_MIN = 0.70;
+    private static final double AI_SCORE_RANGE = 0.15;
+    private static final long AI_DELAY_MIN_MS = 5_000L;
+    private static final long AI_DELAY_MAX_MS = 15_000L;
+
+    private final AiDrawingService aiDrawingService;
+    private final RoundService roundService;
+    private final ObjectMapper objectMapper;
+
+    public AiSubmissionService(AiDrawingService aiDrawingService,
+                               @Lazy RoundService roundService,
+                               ObjectMapper objectMapper) {
+        this.aiDrawingService = aiDrawingService;
+        this.roundService = roundService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Async
+    public void trigger(Long roundId, Long aiParticipantId, String keyword) {
+        try {
+            long delay = ThreadLocalRandom.current().nextLong(AI_DELAY_MIN_MS, AI_DELAY_MAX_MS + 1);
+            Thread.sleep(delay);
+
+            DrawingData drawing = aiDrawingService.generateDrawing(keyword);
+            String imageData = objectMapper.writeValueAsString(drawing.strokes());
+            double score = AI_SCORE_MIN + ThreadLocalRandom.current().nextDouble(AI_SCORE_RANGE);
+
+            roundService.submitAiDrawing(roundId, aiParticipantId, imageData, keyword, score);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("AI 제출 중단. roundId={}", roundId);
+        } catch (Exception e) {
+            log.error("AI 제출 실패. roundId={}", roundId, e);
+        }
+    }
+}

--- a/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import backend.drawrace.domain.round.dto.DrawingData;
+import backend.drawrace.domain.round.dto.SubmitDrawingRequest;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,8 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 @ConditionalOnProperty(name = "ai.mode", havingValue = "quickdraw")
 public class AiSubmissionService {
 
-    private static final double AI_SCORE_MIN = 0.70;
-    private static final double AI_SCORE_RANGE = 0.15;
     private static final long AI_DELAY_MIN_MS = 5_000L;
     private static final long AI_DELAY_MAX_MS = 15_000L;
 
@@ -36,16 +35,15 @@ public class AiSubmissionService {
     }
 
     @Async
-    public void trigger(Long roundId, Long aiParticipantId, String keyword) {
+    public void trigger(Long roundId, Long aiParticipantId, Long aiUserId, String keyword) {
         try {
             long delay = ThreadLocalRandom.current().nextLong(AI_DELAY_MIN_MS, AI_DELAY_MAX_MS + 1);
             Thread.sleep(delay);
 
             DrawingData drawing = aiDrawingService.generateDrawing(keyword);
             String imageData = objectMapper.writeValueAsString(drawing.strokes());
-            double score = AI_SCORE_MIN + ThreadLocalRandom.current().nextDouble(AI_SCORE_RANGE);
 
-            roundService.submitAiDrawing(roundId, aiParticipantId, imageData, keyword, score);
+            roundService.submitDrawing(roundId, aiUserId, new SubmitDrawingRequest(aiParticipantId, imageData));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("AI 제출 중단. roundId={}", roundId);

--- a/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
@@ -33,9 +33,8 @@ public class AiSubmissionService {
     private final RoundService roundService;
     private final ObjectMapper objectMapper;
 
-    public AiSubmissionService(AiDrawingService aiDrawingService,
-                               @Lazy RoundService roundService,
-                               ObjectMapper objectMapper) {
+    public AiSubmissionService(
+            AiDrawingService aiDrawingService, @Lazy RoundService roundService, ObjectMapper objectMapper) {
         this.aiDrawingService = aiDrawingService;
         this.roundService = roundService;
         this.objectMapper = objectMapper;

--- a/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
@@ -59,16 +59,24 @@ public class AiSubmissionService {
 
     /**
      * 실제 제출 로직. 딜레이와 분리되어 있어 테스트에서 직접 호출 가능하다.
+     * 실패 시 빈 데이터로 폴백 제출하여 라운드가 중단되지 않도록 한다.
      */
     void executeSubmission(Long roundId, Long aiParticipantId, Long aiUserId, String keyword) {
         try {
             DrawingData drawing = aiDrawingService.generateDrawing(keyword);
             String imageData = objectMapper.writeValueAsString(drawing.strokes());
-
-            // 기존 submitDrawing을 그대로 사용 (AI 여부는 내부에서 분기)
             roundService.submitDrawing(roundId, aiUserId, new SubmitDrawingRequest(aiParticipantId, imageData));
         } catch (Exception e) {
-            log.error("AI 제출 실패. roundId={}", roundId, e);
+            log.warn("AI 제출 실패. 폴백 제출 시도. roundId={}", roundId, e);
+            submitFallback(roundId, aiParticipantId, aiUserId);
+        }
+    }
+
+    private void submitFallback(Long roundId, Long aiParticipantId, Long aiUserId) {
+        try {
+            roundService.submitDrawing(roundId, aiUserId, new SubmitDrawingRequest(aiParticipantId, "[]"));
+        } catch (Exception e) {
+            log.error("AI 폴백 제출도 실패. 라운드가 중단될 수 있음. roundId={}", roundId, e);
         }
     }
 }

--- a/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
@@ -14,11 +14,18 @@ import backend.drawrace.domain.round.dto.SubmitDrawingRequest;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * AI 유저의 라운드 자동 제출을 담당한다.
+ * ai.mode=quickdraw 일 때만 활성화된다.
+ *
+ * RoundService와 순환 참조가 발생하므로 @Lazy로 지연 주입한다.
+ */
 @Slf4j
 @Service
 @ConditionalOnProperty(name = "ai.mode", havingValue = "quickdraw")
 public class AiSubmissionService {
 
+    // 실제 사람처럼 보이도록 랜덤 딜레이를 준다 (5~15초)
     private static final long AI_DELAY_MIN_MS = 5_000L;
     private static final long AI_DELAY_MAX_MS = 15_000L;
 
@@ -34,6 +41,10 @@ public class AiSubmissionService {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * 비동기로 AI 제출을 실행한다.
+     * QuickDraw 데이터셋에서 키워드에 맞는 그림을 가져와 submitDrawing()을 호출한다.
+     */
     @Async
     public void trigger(Long roundId, Long aiParticipantId, Long aiUserId, String keyword) {
         try {
@@ -43,6 +54,7 @@ public class AiSubmissionService {
             DrawingData drawing = aiDrawingService.generateDrawing(keyword);
             String imageData = objectMapper.writeValueAsString(drawing.strokes());
 
+            // 기존 submitDrawing을 그대로 사용 (AI 여부는 내부에서 분기)
             roundService.submitDrawing(roundId, aiUserId, new SubmitDrawingRequest(aiParticipantId, imageData));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/AiSubmissionService.java
@@ -43,22 +43,30 @@ public class AiSubmissionService {
 
     /**
      * 비동기로 AI 제출을 실행한다.
-     * QuickDraw 데이터셋에서 키워드에 맞는 그림을 가져와 submitDrawing()을 호출한다.
+     * 딜레이 후 executeSubmission()을 호출한다.
      */
     @Async
     public void trigger(Long roundId, Long aiParticipantId, Long aiUserId, String keyword) {
         try {
             long delay = ThreadLocalRandom.current().nextLong(AI_DELAY_MIN_MS, AI_DELAY_MAX_MS + 1);
             Thread.sleep(delay);
+            executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("AI 제출 중단. roundId={}", roundId);
+        }
+    }
 
+    /**
+     * 실제 제출 로직. 딜레이와 분리되어 있어 테스트에서 직접 호출 가능하다.
+     */
+    void executeSubmission(Long roundId, Long aiParticipantId, Long aiUserId, String keyword) {
+        try {
             DrawingData drawing = aiDrawingService.generateDrawing(keyword);
             String imageData = objectMapper.writeValueAsString(drawing.strokes());
 
             // 기존 submitDrawing을 그대로 사용 (AI 여부는 내부에서 분기)
             roundService.submitDrawing(roundId, aiUserId, new SubmitDrawingRequest(aiParticipantId, imageData));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("AI 제출 중단. roundId={}", roundId);
         } catch (Exception e) {
             log.error("AI 제출 실패. roundId={}", roundId, e);
         }

--- a/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
+++ b/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
@@ -3,7 +3,7 @@ package backend.drawrace.domain.round.service;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@ConditionalOnExpression("'${ai.mode:}' == 'gateway' or '${ai.mode:}' == 'quickdraw'")
+@ConditionalOnProperty(name = "ai.mode", havingValue = "gateway")
 @RequiredArgsConstructor
 public class GatewayKeywordGenerator implements KeywordGenerator {
 

--- a/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
+++ b/src/main/java/backend/drawrace/domain/round/service/GatewayKeywordGenerator.java
@@ -14,6 +14,7 @@ import backend.drawrace.global.config.AiProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+// ai.mode=gateway 전용. quickdraw 모드에서는 QuickDrawKeywordGenerator가 대신 활성화된다.
 @Slf4j
 @Service
 @ConditionalOnProperty(name = "ai.mode", havingValue = "gateway")

--- a/src/main/java/backend/drawrace/domain/round/service/QuickDrawKeywordGenerator.java
+++ b/src/main/java/backend/drawrace/domain/round/service/QuickDrawKeywordGenerator.java
@@ -1,0 +1,17 @@
+package backend.drawrace.domain.round.service;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "ai.mode", havingValue = "quickdraw")
+public class QuickDrawKeywordGenerator implements KeywordGenerator {
+
+    @Override
+    public String generateKeyword() {
+        QuickDrawKeyword[] values = QuickDrawKeyword.values();
+        return values[ThreadLocalRandom.current().nextInt(values.length)].name();
+    }
+}

--- a/src/main/java/backend/drawrace/domain/round/service/QuickDrawKeywordGenerator.java
+++ b/src/main/java/backend/drawrace/domain/round/service/QuickDrawKeywordGenerator.java
@@ -5,6 +5,10 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+/**
+ * ai.mode=quickdraw 일 때 활성화되는 키워드 생성기.
+ * AI가 그릴 수 있는 QuickDraw 345종 중 랜덤으로 제시어를 선택한다.
+ */
 @Component
 @ConditionalOnProperty(name = "ai.mode", havingValue = "quickdraw")
 public class QuickDrawKeywordGenerator implements KeywordGenerator {

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -3,6 +3,7 @@ package backend.drawrace.domain.round.service;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +29,6 @@ import backend.drawrace.domain.round.validator.RoundValidator;
 import backend.drawrace.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.ObjectProvider;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -439,7 +439,8 @@ public class RoundService {
         participants.stream()
                 .filter(p -> p.getUserId().isAi())
                 .findFirst()
-                .ifPresent(ai -> service.trigger(round.getId(), ai.getId(), ai.getUserId().getId(), round.getKeyword()));
+                .ifPresent(ai -> service.trigger(
+                        round.getId(), ai.getId(), ai.getUserId().getId(), round.getKeyword()));
     }
 
     private void sendFinalWinnerNotice(Long roomId, String nickname) {

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -1,6 +1,7 @@
 package backend.drawrace.domain.round.service;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -103,8 +104,10 @@ public class RoundService {
         // 방 소속 참가자인지 확인
         Participant participant = getValidParticipant(round, request.getParticipantId());
 
-        // 로그인한 사용자 본인의 참가 정보인지 확인
-        roundValidator.validateParticipantOwner(participant, userId);
+        // AI 참가자는 인증 검증 스킵
+        if (!participant.getUserId().isAi()) {
+            roundValidator.validateParticipantOwner(participant, userId);
+        }
 
         // 이번 라운드 제출 대상인지 확인
         boolean canPlay =
@@ -116,10 +119,14 @@ public class RoundService {
                 roundSubmissionRepository.existsByRoundIdAndParticipantId(round.getId(), participant.getId());
         roundValidator.validateNotSubmitted(alreadySubmitted);
 
-        // AI 판독 수행
-        // - 내부적으로 1회 재시도
-        // - 최종 실패 시 예외를 던져 제출을 실패 처리한다
-        AiInferenceResponse aiResult = aiInferenceService.infer(request.getImageData(), round.getKeyword());
+        // AI 참가자는 추론 스킵 후 점수 고정, 인간 참가자는 추론 수행
+        AiInferenceResponse aiResult;
+        if (participant.getUserId().isAi()) {
+            double score = 0.70 + ThreadLocalRandom.current().nextDouble(0.15);
+            aiResult = new AiInferenceResponse(round.getKeyword(), score);
+        } else {
+            aiResult = aiInferenceService.infer(request.getImageData(), round.getKeyword());
+        }
 
         // 제출 기록 저장
         RoundSubmission submission = RoundSubmission.create(
@@ -427,43 +434,7 @@ public class RoundService {
         participants.stream()
                 .filter(p -> p.getUserId().isAi())
                 .findFirst()
-                .ifPresent(ai -> service.trigger(round.getId(), ai.getId(), round.getKeyword()));
-    }
-
-    @Transactional
-    public void submitAiDrawing(Long roundId, Long aiParticipantId, String imageData, String aiAnswer, double score) {
-        Round round = roundRepository.findById(roundId)
-                .orElseThrow(() -> new ServiceException("404-2", "존재하지 않는 라운드입니다."));
-
-        if (!round.isActive()) {
-            log.info("AI 제출 취소: 이미 종료된 라운드. roundId={}", roundId);
-            return;
-        }
-
-        if (roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)) {
-            log.info("AI 제출 취소: 이미 제출됨. roundId={}", roundId);
-            return;
-        }
-
-        Participant aiParticipant = participantRepository.findById(aiParticipantId)
-                .orElseThrow(() -> new ServiceException("404-4", "AI 참가자를 찾을 수 없습니다."));
-
-        RoundSubmission submission = RoundSubmission.create(round, aiParticipant, imageData, aiAnswer, score);
-        roundSubmissionRepository.save(submission);
-
-        long submittedCount = roundSubmissionRepository.countByRoundId(roundId);
-        long totalCount = roundParticipantRepository.countByRoundId(roundId);
-
-        if (submittedCount < totalCount) {
-            return;
-        }
-
-        AiInferenceResponse aiResult = new AiInferenceResponse(aiAnswer, score);
-        SubmitDrawingResponse response = handleRoundCompletion(round, aiResult, submittedCount, totalCount);
-
-        if (response.isRoundFinished()) {
-            messagingTemplate.convertAndSend("/sub/rooms/" + round.getRoom().getId(), response);
-        }
+                .ifPresent(ai -> service.trigger(round.getId(), ai.getId(), ai.getUserId().getId(), round.getKeyword()));
     }
 
     private void sendFinalWinnerNotice(Long roomId, String nickname) {

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -119,7 +119,8 @@ public class RoundService {
                 roundSubmissionRepository.existsByRoundIdAndParticipantId(round.getId(), participant.getId());
         roundValidator.validateNotSubmitted(alreadySubmitted);
 
-        // AI 참가자는 추론 스킵 후 점수 고정, 인간 참가자는 추론 수행
+        // AI는 스트로크 데이터를 비전 모델로 판독할 수 없으므로 점수를 고정한다 (0.70~0.85)
+        // 인간이 잘 그리면 AI를 이길 수 있는 수준으로 설정
         AiInferenceResponse aiResult;
         if (participant.getUserId().isAi()) {
             double score = 0.70 + ThreadLocalRandom.current().nextDouble(0.15);
@@ -427,6 +428,10 @@ public class RoundService {
                 .toList();
     }
 
+    /**
+     * 참가자 중 AI가 있으면 AiSubmissionService를 통해 자동 제출을 예약한다.
+     * quickdraw 모드가 아니면 AiSubmissionService 빈이 없으므로 아무것도 하지 않는다.
+     */
     private void triggerAiIfPresent(Round round, List<Participant> participants) {
         AiSubmissionService service = aiSubmissionServiceProvider.getIfAvailable();
         if (service == null) return;

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -27,7 +27,10 @@ import backend.drawrace.domain.round.validator.RoundValidator;
 import backend.drawrace.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -42,6 +45,7 @@ public class RoundService {
     private final RoundValidator roundValidator;
     private final AiInferenceService aiInferenceService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
 
     /**
      * 게임 시작 처리
@@ -67,6 +71,7 @@ public class RoundService {
 
         List<Participant> participants = participantRepository.findByRoomId(roomId);
         saveRoundParticipants(savedRound, participants);
+        triggerAiIfPresent(savedRound, participants);
 
         RoundStartResponse response = RoundStartResponse.from(savedRound);
 
@@ -276,6 +281,7 @@ public class RoundService {
 
             List<Participant> participants = participantRepository.findByRoomId(room.getId());
             saveRoundParticipants(nextRound, participants);
+            triggerAiIfPresent(nextRound, participants);
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
@@ -343,6 +349,7 @@ public class RoundService {
         // 동점이면 결승 라운드 생성
         Round tieBreakerRound = createTieBreakerRound(room, round.getRoundNumber() + 1);
         saveRoundParticipants(tieBreakerRound, topScorers);
+        triggerAiIfPresent(tieBreakerRound, topScorers);
 
         return SubmitDrawingResponse.builder()
                 .roundId(round.getId())
@@ -411,6 +418,52 @@ public class RoundService {
         return participants.stream()
                 .filter(participant -> participant.getRoundWinCount() == maxWinCount)
                 .toList();
+    }
+
+    private void triggerAiIfPresent(Round round, List<Participant> participants) {
+        AiSubmissionService service = aiSubmissionServiceProvider.getIfAvailable();
+        if (service == null) return;
+
+        participants.stream()
+                .filter(p -> p.getUserId().isAi())
+                .findFirst()
+                .ifPresent(ai -> service.trigger(round.getId(), ai.getId(), round.getKeyword()));
+    }
+
+    @Transactional
+    public void submitAiDrawing(Long roundId, Long aiParticipantId, String imageData, String aiAnswer, double score) {
+        Round round = roundRepository.findById(roundId)
+                .orElseThrow(() -> new ServiceException("404-2", "존재하지 않는 라운드입니다."));
+
+        if (!round.isActive()) {
+            log.info("AI 제출 취소: 이미 종료된 라운드. roundId={}", roundId);
+            return;
+        }
+
+        if (roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)) {
+            log.info("AI 제출 취소: 이미 제출됨. roundId={}", roundId);
+            return;
+        }
+
+        Participant aiParticipant = participantRepository.findById(aiParticipantId)
+                .orElseThrow(() -> new ServiceException("404-4", "AI 참가자를 찾을 수 없습니다."));
+
+        RoundSubmission submission = RoundSubmission.create(round, aiParticipant, imageData, aiAnswer, score);
+        roundSubmissionRepository.save(submission);
+
+        long submittedCount = roundSubmissionRepository.countByRoundId(roundId);
+        long totalCount = roundParticipantRepository.countByRoundId(roundId);
+
+        if (submittedCount < totalCount) {
+            return;
+        }
+
+        AiInferenceResponse aiResult = new AiInferenceResponse(aiAnswer, score);
+        SubmitDrawingResponse response = handleRoundCompletion(round, aiResult, submittedCount, totalCount);
+
+        if (response.isRoundFinished()) {
+            messagingTemplate.convertAndSend("/sub/rooms/" + round.getRoom().getId(), response);
+        }
     }
 
     private void sendFinalWinnerNotice(Long roomId, String nickname) {

--- a/src/main/java/backend/drawrace/global/config/AppConfig.java
+++ b/src/main/java/backend/drawrace/global/config/AppConfig.java
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import backend.drawrace.domain.round.service.AiInferenceService;
 import backend.drawrace.domain.round.service.KeywordGenerator;
@@ -11,6 +12,7 @@ import backend.drawrace.domain.round.service.MockAiInferenceService;
 import backend.drawrace.domain.round.service.MockKeywordGenerator;
 
 @Configuration
+@EnableAsync
 @EnableConfigurationProperties(AiProperties.class)
 public class AppConfig {
 

--- a/src/main/java/backend/drawrace/global/config/AppConfig.java
+++ b/src/main/java/backend/drawrace/global/config/AppConfig.java
@@ -12,7 +12,7 @@ import backend.drawrace.domain.round.service.MockAiInferenceService;
 import backend.drawrace.domain.round.service.MockKeywordGenerator;
 
 @Configuration
-@EnableAsync
+@EnableAsync  // AiSubmissionService의 @Async 비동기 처리를 위해 필요
 @EnableConfigurationProperties(AiProperties.class)
 public class AppConfig {
 

--- a/src/main/java/backend/drawrace/global/config/AppConfig.java
+++ b/src/main/java/backend/drawrace/global/config/AppConfig.java
@@ -12,7 +12,7 @@ import backend.drawrace.domain.round.service.MockAiInferenceService;
 import backend.drawrace.domain.round.service.MockKeywordGenerator;
 
 @Configuration
-@EnableAsync  // AiSubmissionService의 @Async 비동기 처리를 위해 필요
+@EnableAsync // AiSubmissionService의 @Async 비동기 처리를 위해 필요
 @EnableConfigurationProperties(AiProperties.class)
 public class AppConfig {
 

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -114,6 +114,8 @@ class RoomServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(participantRepository.findByUserId(user)).willReturn(Optional.of(participant));
+        given(participant.getUserId()).willReturn(user);
+        given(room.getParticipants()).willReturn(List.of(participant));
 
         RoomUpdateResponse response = roomService.leaveRoom(userId);
 

--- a/src/test/java/backend/drawrace/domain/round/service/AiSubmissionServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/AiSubmissionServiceTest.java
@@ -47,9 +47,13 @@ class AiSubmissionServiceTest {
         aiSubmissionService.executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
 
         then(aiDrawingService).should().generateDrawing(keyword);
-        then(roundService).should().submitDrawing(eq(roundId), eq(aiUserId), argThat(req ->
-                req.getParticipantId().equals(aiParticipantId)
-                        && req.getImageData().equals("[[[0,1],[2,3]]]")));
+        then(roundService)
+                .should()
+                .submitDrawing(
+                        eq(roundId),
+                        eq(aiUserId),
+                        argThat(req -> req.getParticipantId().equals(aiParticipantId)
+                                && req.getImageData().equals("[[[0,1],[2,3]]]")));
     }
 
     @Test
@@ -65,8 +69,13 @@ class AiSubmissionServiceTest {
         aiSubmissionService.executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
 
         // 폴백으로 빈 데이터 제출 시도
-        then(roundService).should().submitDrawing(eq(roundId), eq(aiUserId),
-                argThat(req -> req.getParticipantId().equals(aiParticipantId) && req.getImageData().equals("[]")));
+        then(roundService)
+                .should()
+                .submitDrawing(
+                        eq(roundId),
+                        eq(aiUserId),
+                        argThat(req -> req.getParticipantId().equals(aiParticipantId)
+                                && req.getImageData().equals("[]")));
     }
 
     @Test
@@ -78,7 +87,8 @@ class AiSubmissionServiceTest {
         String keyword = "사과";
 
         given(aiDrawingService.generateDrawing(keyword)).willThrow(new RuntimeException("그림 생성 실패"));
-        willThrow(new RuntimeException("폴백 실패")).given(roundService)
+        willThrow(new RuntimeException("폴백 실패"))
+                .given(roundService)
                 .submitDrawing(any(), any(), any(SubmitDrawingRequest.class));
 
         // 예외가 외부로 전파되지 않아야 한다

--- a/src/test/java/backend/drawrace/domain/round/service/AiSubmissionServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/AiSubmissionServiceTest.java
@@ -53,8 +53,8 @@ class AiSubmissionServiceTest {
     }
 
     @Test
-    @DisplayName("그림 생성 중 예외가 발생해도 submitDrawing은 호출되지 않는다")
-    void executeSubmission_whenDrawingFails_doesNotCallSubmitDrawing() {
+    @DisplayName("그림 생성 실패 시 빈 데이터로 폴백 제출한다")
+    void executeSubmission_whenDrawingFails_submitsFallback() throws Exception {
         Long roundId = 1L;
         Long aiParticipantId = 100L;
         Long aiUserId = 200L;
@@ -64,21 +64,21 @@ class AiSubmissionServiceTest {
 
         aiSubmissionService.executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
 
-        then(roundService).should(never()).submitDrawing(any(), any(), any());
+        // 폴백으로 빈 데이터 제출 시도
+        then(roundService).should().submitDrawing(eq(roundId), eq(aiUserId),
+                argThat(req -> req.getParticipantId().equals(aiParticipantId) && req.getImageData().equals("[]")));
     }
 
     @Test
-    @DisplayName("submitDrawing 중 예외가 발생해도 예외가 전파되지 않는다")
-    void executeSubmission_whenSubmitFails_doesNotThrow() throws Exception {
+    @DisplayName("폴백 제출도 실패하면 예외가 전파되지 않는다")
+    void executeSubmission_whenFallbackFails_doesNotThrow() throws Exception {
         Long roundId = 1L;
         Long aiParticipantId = 100L;
         Long aiUserId = 200L;
         String keyword = "사과";
 
-        DrawingData drawing = new DrawingData(List.of());
-        given(aiDrawingService.generateDrawing(keyword)).willReturn(drawing);
-        given(objectMapper.writeValueAsString(any())).willReturn("[]");
-        willThrow(new RuntimeException("제출 실패")).given(roundService)
+        given(aiDrawingService.generateDrawing(keyword)).willThrow(new RuntimeException("그림 생성 실패"));
+        willThrow(new RuntimeException("폴백 실패")).given(roundService)
                 .submitDrawing(any(), any(), any(SubmitDrawingRequest.class));
 
         // 예외가 외부로 전파되지 않아야 한다

--- a/src/test/java/backend/drawrace/domain/round/service/AiSubmissionServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/AiSubmissionServiceTest.java
@@ -1,0 +1,87 @@
+package backend.drawrace.domain.round.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import backend.drawrace.domain.round.dto.DrawingData;
+import backend.drawrace.domain.round.dto.SubmitDrawingRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AiSubmissionServiceTest {
+
+    @Mock
+    private AiDrawingService aiDrawingService;
+
+    @Mock
+    private RoundService roundService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private AiSubmissionService aiSubmissionService;
+
+    @Test
+    @DisplayName("executeSubmission 호출 시 그림을 생성하고 submitDrawing을 호출한다")
+    void executeSubmission_callsSubmitDrawing() throws Exception {
+        Long roundId = 1L;
+        Long aiParticipantId = 100L;
+        Long aiUserId = 200L;
+        String keyword = "사과";
+
+        DrawingData drawing = new DrawingData(List.of(List.of(List.of(0, 1), List.of(2, 3))));
+        given(aiDrawingService.generateDrawing(keyword)).willReturn(drawing);
+        given(objectMapper.writeValueAsString(drawing.strokes())).willReturn("[[[0,1],[2,3]]]");
+
+        aiSubmissionService.executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
+
+        then(aiDrawingService).should().generateDrawing(keyword);
+        then(roundService).should().submitDrawing(eq(roundId), eq(aiUserId), argThat(req ->
+                req.getParticipantId().equals(aiParticipantId)
+                        && req.getImageData().equals("[[[0,1],[2,3]]]")));
+    }
+
+    @Test
+    @DisplayName("그림 생성 중 예외가 발생해도 submitDrawing은 호출되지 않는다")
+    void executeSubmission_whenDrawingFails_doesNotCallSubmitDrawing() {
+        Long roundId = 1L;
+        Long aiParticipantId = 100L;
+        Long aiUserId = 200L;
+        String keyword = "사과";
+
+        given(aiDrawingService.generateDrawing(keyword)).willThrow(new RuntimeException("그림 생성 실패"));
+
+        aiSubmissionService.executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
+
+        then(roundService).should(never()).submitDrawing(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("submitDrawing 중 예외가 발생해도 예외가 전파되지 않는다")
+    void executeSubmission_whenSubmitFails_doesNotThrow() throws Exception {
+        Long roundId = 1L;
+        Long aiParticipantId = 100L;
+        Long aiUserId = 200L;
+        String keyword = "사과";
+
+        DrawingData drawing = new DrawingData(List.of());
+        given(aiDrawingService.generateDrawing(keyword)).willReturn(drawing);
+        given(objectMapper.writeValueAsString(any())).willReturn("[]");
+        willThrow(new RuntimeException("제출 실패")).given(roundService)
+                .submitDrawing(any(), any(), any(SubmitDrawingRequest.class));
+
+        // 예외가 외부로 전파되지 않아야 한다
+        aiSubmissionService.executeSubmission(roundId, aiParticipantId, aiUserId, keyword);
+    }
+}

--- a/src/test/java/backend/drawrace/domain/round/service/QuickDrawKeywordGeneratorTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/QuickDrawKeywordGeneratorTest.java
@@ -2,10 +2,10 @@ package backend.drawrace.domain.round.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/backend/drawrace/domain/round/service/QuickDrawKeywordGeneratorTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/QuickDrawKeywordGeneratorTest.java
@@ -1,0 +1,42 @@
+package backend.drawrace.domain.round.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QuickDrawKeywordGeneratorTest {
+
+    private final QuickDrawKeywordGenerator generator = new QuickDrawKeywordGenerator();
+
+    @Test
+    @DisplayName("생성된 키워드는 QuickDraw 345종 중 하나다")
+    void generateKeyword_returnsValidQuickDrawKeyword() {
+        Set<String> validNames = Arrays.stream(QuickDrawKeyword.values())
+                .map(QuickDrawKeyword::name)
+                .collect(Collectors.toSet());
+
+        for (int i = 0; i < 100; i++) {
+            String keyword = generator.generateKeyword();
+            assertThat(validNames).contains(keyword);
+        }
+    }
+
+    @Test
+    @DisplayName("반복 호출 시 다양한 키워드가 생성된다")
+    void generateKeyword_returnsVaryingKeywords() {
+        Set<String> results = new HashSet<>();
+
+        for (int i = 0; i < 100; i++) {
+            results.add(generator.generateKeyword());
+        }
+
+        // 100번 중 모두 같은 단어가 나올 확률은 사실상 0에 가까움
+        assertThat(results.size()).isGreaterThan(1);
+    }
+}

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -68,6 +68,9 @@ class RoundServiceTest {
     @Mock
     private AiInferenceService aiInferenceService;
 
+    @Mock
+    private org.springframework.beans.factory.ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
+
     @InjectMocks
     private RoundService roundService;
 
@@ -699,6 +702,74 @@ class RoundServiceTest {
         assertThatThrownBy(() -> roundService.getCurrentRound(roomId, userId))
                 .isInstanceOf(ServiceException.class)
                 .hasMessageContaining("해당 방 참가자만 현재 라운드를 조회할 수 있습니다");
+    }
+
+    @Test
+    @DisplayName("AI 참가자는 인증 검증을 거치지 않고 제출에 성공한다")
+    void submitDrawing_ai_skipsOwnerValidation() throws Exception {
+        Long roomId = 1L;
+        Long roundId = 10L;
+        Long aiParticipantId = 100L;
+        Long aiUserId = 999L;
+
+        Room room = createRoom(roomId, true, 1L);
+        Round round = createInProgressRound(roundId, room, 1, "사과");
+        Participant aiParticipant = createAiParticipant(aiParticipantId, room, aiUserId);
+
+        SubmitDrawingRequest request = createSubmitDrawingRequest(aiParticipantId, "stroke-json");
+
+        given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(participantRepository.findByIdAndRoomId(aiParticipantId, roomId)).willReturn(Optional.of(aiParticipant));
+        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(true);
+        given(roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(false);
+        given(roundSubmissionRepository.countByRoundId(roundId)).willReturn(1L);
+        given(roundParticipantRepository.countByRoundId(roundId)).willReturn(2L);
+
+        roundService.submitDrawing(roundId, aiUserId, request);
+
+        // AI는 validateParticipantOwner를 호출하지 않아야 한다
+        then(roundValidator).should(never()).validateParticipantOwner(any(), any());
+        then(roundSubmissionRepository).should().save(any(RoundSubmission.class));
+    }
+
+    @Test
+    @DisplayName("AI 참가자는 추론 서비스를 호출하지 않고 0.70~0.85 사이의 점수를 받는다")
+    void submitDrawing_ai_usesFixedScoreWithoutInference() throws Exception {
+        Long roomId = 1L;
+        Long roundId = 10L;
+        Long aiParticipantId = 100L;
+        Long aiUserId = 999L;
+
+        Room room = createRoom(roomId, true, 1L);
+        Round round = createInProgressRound(roundId, room, 1, "사과");
+        Participant aiParticipant = createAiParticipant(aiParticipantId, room, aiUserId);
+
+        SubmitDrawingRequest request = createSubmitDrawingRequest(aiParticipantId, "stroke-json");
+
+        given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(participantRepository.findByIdAndRoomId(aiParticipantId, roomId)).willReturn(Optional.of(aiParticipant));
+        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(true);
+        given(roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(false);
+        given(roundSubmissionRepository.countByRoundId(roundId)).willReturn(1L);
+        given(roundParticipantRepository.countByRoundId(roundId)).willReturn(2L);
+
+        roundService.submitDrawing(roundId, aiUserId, request);
+
+        // AI는 추론 서비스를 호출하지 않아야 한다
+        then(aiInferenceService).should(never()).infer(any(), any());
+
+        // 저장된 제출의 점수가 0.70~0.85 사이인지 확인
+        then(roundSubmissionRepository).should().save(argThat(submission ->
+                submission.getScore() >= 0.70 && submission.getScore() < 0.85));
+    }
+
+    private Participant createAiParticipant(Long participantId, Room room, Long aiUserId) throws Exception {
+        User user = mock(User.class);
+        given(user.isAi()).willReturn(true);
+
+        Participant participant = Participant.builder().userId(user).room(room).isHost(false).build();
+        setField(participant, "id", participantId);
+        return participant;
     }
 
     private Room createRoom(Long id, boolean isPlaying, Long hostId) throws Exception {

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -720,8 +720,10 @@ class RoundServiceTest {
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(aiParticipantId, roomId)).willReturn(Optional.of(aiParticipant));
-        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(true);
-        given(roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(false);
+        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId))
+                .willReturn(true);
+        given(roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId))
+                .willReturn(false);
         given(roundSubmissionRepository.countByRoundId(roundId)).willReturn(1L);
         given(roundParticipantRepository.countByRoundId(roundId)).willReturn(2L);
 
@@ -748,8 +750,10 @@ class RoundServiceTest {
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(aiParticipantId, roomId)).willReturn(Optional.of(aiParticipant));
-        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(true);
-        given(roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId)).willReturn(false);
+        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId))
+                .willReturn(true);
+        given(roundSubmissionRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId))
+                .willReturn(false);
         given(roundSubmissionRepository.countByRoundId(roundId)).willReturn(1L);
         given(roundParticipantRepository.countByRoundId(roundId)).willReturn(2L);
 
@@ -759,15 +763,17 @@ class RoundServiceTest {
         then(aiInferenceService).should(never()).infer(any(), any());
 
         // 저장된 제출의 점수가 0.70~0.85 사이인지 확인
-        then(roundSubmissionRepository).should().save(argThat(submission ->
-                submission.getScore() >= 0.70 && submission.getScore() < 0.85));
+        then(roundSubmissionRepository)
+                .should()
+                .save(argThat(submission -> submission.getScore() >= 0.70 && submission.getScore() < 0.85));
     }
 
     private Participant createAiParticipant(Long participantId, Room room, Long aiUserId) throws Exception {
         User user = mock(User.class);
         given(user.isAi()).willReturn(true);
 
-        Participant participant = Participant.builder().userId(user).room(room).isHost(false).build();
+        Participant participant =
+                Participant.builder().userId(user).room(room).isHost(false).build();
         setField(participant, "id", participantId);
         return participant;
     }

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
@@ -62,6 +63,9 @@ class RoundServiceWebSocketTest {
 
     @Mock
     private RankingService rankingService;
+
+    @Mock
+    private ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
 
     @Test
     @DisplayName("라운드 종료 시 웹소켓으로 결과가 전송되는지 확인한다")


### PR DESCRIPTION
## 📝 작업 내용
- AI 게임 참여 로직 구현

## 🔢 작업 단계

### AI 게임 참여 로직
- [ ] QuickDrawKeywordGenerator: ai.mode=quickdraw일 때 345종 중 랜덤 키워드 선택
- [ ] AiSubmissionService: 비동기 자동 제출 (5~15초 랜덤 딜레이, 폴백 처리)
- [ ] RoundService.submitDrawing() 통합: AI는 소유자 검증 스킵, 점수 0.70~0.85 랜덤 부여
- [ ] triggerAiIfPresent(): 모든 라운드(일반, 다음 라운드, 결승) 시작 시 AI 트리거

### API 추가
- [ ] DELETE /api/rooms/{roomId}/ai-participants — AI 참가자 제거
- [ ] RoomInfoRes.ParticipantDto에 isAi 필드 추가

### 버그 수정
- [ ] AI 중복 추가 방지
- [ ] 방장 위임 시 AI 제외
- [ ] AI 통계 기록 제외
- [ ] AI 폴백 실패 시 라운드 중단 방지
- [ ] AI만 남을 때 방 자동 삭제 
- [ ] 게임 중 AI 제거 방지 

### API 추가

- [ ] DELETE /api/rooms/{roomId}/ai-participants — AI 참가자 제거
- [ ] RoomInfoRes.ParticipantDto에 isAi 필드 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #38