### PR TITLE
[Feat] ai 기반 실시간 채팅 검열 시스템 구축 및 동시성 문제 수정

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
+++ b/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
@@ -3,9 +3,15 @@ package backend.drawrace.domain.chat.controller;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
+import backend.drawrace.domain.chat.service.ChatModerationService;
+import backend.drawrace.domain.user.entity.User;
+import backend.drawrace.domain.user.repository.UserRepository;
+import backend.drawrace.global.exception.ServiceException;
+import backend.drawrace.global.security.SecurityUser;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,9 +20,29 @@ import lombok.RequiredArgsConstructor;
 public class ChatController {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final UserRepository userRepository;
+    private final ChatModerationService chatModerationService; // [추가]
 
     @MessageMapping("/rooms/{roomId}/chat")
-    public void sendChatMessage(@DestinationVariable Long roomId, ChatMessageDto chatMessage) {
+    public void sendChatMessage(
+            @DestinationVariable Long roomId, ChatMessageDto chatMessage, Authentication authentication) {
+
+        // 빈 메시지나 공백만 있는 메시지
+        if (chatMessage.getMessage() == null || chatMessage.getMessage().trim().isEmpty()) {
+            return; // 아무것도 하지 않고 종료
+        }
+
+        SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
+
+        User user = userRepository
+                .findById(securityUser.getUserId())
+                .orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
+
+        // AI 검열 실행
+        String filteredMessage = chatModerationService.filterMessage(chatMessage.getMessage());
+
+        chatMessage.setSender(user.getNickname());
+        chatMessage.setMessage(filteredMessage);
         // 일반 채팅은 TALK 타입으로 고정하여 브로드캐스팅
         chatMessage.setType(ChatMessageDto.MessageType.TALK);
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);

--- a/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
@@ -1,0 +1,69 @@
+package backend.drawrace.domain.chat.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import backend.drawrace.domain.round.dto.gateway.GatewayChatRequest;
+import backend.drawrace.domain.round.dto.gateway.GatewayChatResponse;
+import backend.drawrace.global.config.AiProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatModerationService {
+
+    private final AiProperties aiProperties;
+
+    public String filterMessage(String originalMessage) {
+        try {
+            // 분리된 메서드 호출
+            String aiDecision = getAiDecision(originalMessage);
+
+            if (aiDecision.contains("UNSAFE")) {
+                return "⚠️ 클린한 채팅 문화를 만들어주세요!";
+            }
+        } catch (Exception e) {
+            log.error("AI 검열 중 오류 발생: {}", e.getMessage());
+            return originalMessage;
+        }
+        return originalMessage;
+    }
+
+    protected String getAiDecision(String message) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(aiProperties.baseUrl())
+                .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey())
+                .build();
+
+        // 프롬프트
+        String systemPrompt = """
+            너는 실시간 게임의 채팅 검열관이야.
+            사용자의 메시지가 욕설, 비방, 성적인 내용, 혹은 부적절한 언어를 포함하고 있는지 판단해.
+            부적절하다면 무조건 'UNSAFE'라고만 답하고,
+            괜찮다면 'SAFE'라고만 답해.
+            설명이나 다른 말은 절대 하지 마.
+            """;
+
+        GatewayChatRequest request = GatewayChatRequest.builder()
+                .model(aiProperties.model())
+                .messages(List.of(
+                        GatewayChatRequest.systemMessage(systemPrompt), GatewayChatRequest.userMessage(message)))
+                .temperature(0.0)
+                .build();
+
+        GatewayChatResponse response = restClient
+                .post()
+                .uri("/chat/completions")
+                .body(request)
+                .retrieve()
+                .toEntity(GatewayChatResponse.class)
+                .getBody();
+
+        return response.getChoices().get(0).getMessage().getContent().trim();
+    }
+}

--- a/src/main/java/backend/drawrace/domain/room/entity/Room.java
+++ b/src/main/java/backend/drawrace/domain/room/entity/Room.java
@@ -47,6 +47,9 @@ public class Room extends BaseEntity {
     @Builder.Default
     private List<Participant> participants = new ArrayList<>();
 
+    @Version // 동시성 제어를 위한 버전 관리
+    private Long version;
+
     public void addParticipant(Participant participant) {
         this.participants.add(participant);
         this.curPlayers++;

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,47 +102,72 @@ public class RoomService {
 
     @Transactional
     public RoomUpdateResponse joinRoom(Long roomId, Long userId, String inputPassword) {
-        Room room = roomRepository.findById(roomId).orElseThrow(() -> new ServiceException("404-2", "방을 찾을 수 없습니다."));
+        int maxRetries = 3; // 최대 3번 시도
+        int retryCount = 0;
 
-        // 비밀번호 체크 (방에 비밀번호가 걸려있는 경우만)
-        if (room.getPassword() != null && !room.getPassword().isEmpty()) {
-            if (!room.getPassword().equals(inputPassword)) {
-                throw new ServiceException("400-4", "비밀번호가 일치하지 않습니다.");
+        while (retryCount < maxRetries) {
+            try {
+                Room room = roomRepository
+                        .findById(roomId)
+                        .orElseThrow(() -> new ServiceException("404-2", "방을 찾을 수 없습니다."));
+
+                // 비밀번호 체크 (방에 비밀번호가 걸려있는 경우만)
+                if (room.getPassword() != null && !room.getPassword().isEmpty()) {
+                    if (!room.getPassword().equals(inputPassword)) {
+                        throw new ServiceException("400-4", "비밀번호가 일치하지 않습니다.");
+                    }
+                }
+
+                if (room.isPlaying()) {
+                    throw new ServiceException("400-2", "이미 게임이 시작된 방입니다.");
+                }
+
+                if (room.getCurPlayers() >= room.getMaxPlayers()) {
+                    throw new ServiceException("400-3", "방 인원이 초과되었습니다.");
+                }
+
+                User user = userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
+
+                Participant participant = Participant.builder()
+                        .userId(user)
+                        .room(room)
+                        .isHost(false)
+                        .build();
+
+                participantRepository.save(participant);
+                room.addParticipant(participant);
+
+                ChatMessageDto enterNotice = ChatMessageDto.builder()
+                        .type(ChatMessageDto.MessageType.NOTICE)
+                        .roomId(roomId)
+                        .sender("System")
+                        .message(user.getNickname() + "님이 입장하셨습니다.")
+                        .build();
+                messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", enterNotice);
+
+                return RoomUpdateResponse.builder()
+                        .roomId(roomId)
+                        .type("USER_ENTER")
+                        .participants(room.getParticipants().stream()
+                                .map(p -> p.getUserId().getNickname())
+                                .toList())
+                        .message(user.getNickname() + "님이 입장하셨습니다.")
+                        .build();
+            } catch (ObjectOptimisticLockingFailureException e) {
+                retryCount++;
+                if (retryCount >= maxRetries) {
+                    throw new ServiceException("409-1", "접속자가 너무 많아 입장에 실패했습니다. 다시 시도해 주세요.");
+                }
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
-
-        if (room.isPlaying()) {
-            throw new ServiceException("400-2", "이미 게임이 시작된 방입니다.");
-        }
-
-        if (room.getCurPlayers() >= room.getMaxPlayers()) {
-            throw new ServiceException("400-3", "방 인원이 초과되었습니다.");
-        }
-
-        User user = userRepository.findById(userId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
-
-        Participant participant =
-                Participant.builder().userId(user).room(room).isHost(false).build();
-
-        participantRepository.save(participant);
-        room.addParticipant(participant);
-
-        ChatMessageDto enterNotice = ChatMessageDto.builder()
-                .type(ChatMessageDto.MessageType.NOTICE)
-                .roomId(roomId)
-                .sender("System")
-                .message(user.getNickname() + "님이 입장하셨습니다.")
-                .build();
-        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", enterNotice);
-
-        return RoomUpdateResponse.builder()
-                .roomId(roomId)
-                .type("USER_ENTER")
-                .participants(room.getParticipants().stream()
-                        .map(p -> p.getUserId().getNickname())
-                        .toList())
-                .message(user.getNickname() + "님이 입장하셨습니다.")
-                .build();
+        throw new ServiceException("500-0", "알 수 없는 오류가 발생했습니다.");
     }
 
     @Transactional

--- a/src/main/java/backend/drawrace/global/security/StompHandler.java
+++ b/src/main/java/backend/drawrace/global/security/StompHandler.java
@@ -9,6 +9,9 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+import backend.drawrace.domain.room.repository.ParticipantRepository;
+import backend.drawrace.global.exception.ServiceException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,10 +21,13 @@ import lombok.extern.slf4j.Slf4j;
 public class StompHandler implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final ParticipantRepository participantRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) return message;
 
         // CONNECT 프레임일 때(처음 연결할 때) 토큰 검증
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
@@ -40,6 +46,46 @@ public class StompHandler implements ChannelInterceptor {
                 throw new RuntimeException("인증 정보가 유효하지 않습니다.");
             }
         }
+
+        // 구독 시 권한 체크
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            String destination = accessor.getDestination(); // 예: /sub/rooms/10/chat
+            Long roomId = extractRoomId(destination);
+
+            if (roomId != null) {
+                // 현재 인증된 유저 정보 가져오기
+                Authentication authentication = (Authentication) accessor.getUser();
+                if (authentication == null) {
+                    throw new ServiceException("401-1", "인증 정보가 없습니다.");
+                }
+
+                SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
+                Long userId = securityUser.getUserId();
+
+                // DB에서 해당 유저가 이 방의 참여자인지 확인
+                boolean isParticipant = participantRepository.existsByRoomIdAndUserId_Id(roomId, userId);
+
+                if (!isParticipant) {
+                    log.warn("인가되지 않은 구독 시도: 유저 {}, 방 {}", userId, roomId);
+                    throw new ServiceException("403-1", "해당 방에 접근 권한이 없습니다.");
+                }
+            }
+        }
         return message;
+    }
+
+    private Long extractRoomId(String destination) {
+        try {
+            if (destination == null || !destination.startsWith("/sub/rooms/")) return null;
+
+            // /sub/rooms/{roomId} 형식에서 숫자 추출
+            String[] parts = destination.split("/");
+            if (parts.length >= 4) {
+                return Long.parseLong(parts[3]);
+            }
+        } catch (Exception e) {
+            log.error("roomId 추출 실패: {}", destination);
+        }
+        return null;
     }
 }

--- a/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
@@ -3,6 +3,8 @@ package backend.drawrace.domain.chat.controller;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,8 +12,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
+import backend.drawrace.domain.chat.service.ChatModerationService;
+import backend.drawrace.domain.user.entity.User;
+import backend.drawrace.domain.user.repository.UserRepository;
+import backend.drawrace.global.security.SecurityUser;
 
 @ExtendWith(MockitoExtension.class)
 class ChatControllerTest {
@@ -22,17 +30,35 @@ class ChatControllerTest {
     @Mock
     private SimpMessagingTemplate messagingTemplate;
 
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatModerationService chatModerationService;
+
     @Test
     @DisplayName("사용자가 채팅을 보내면 TALK 타입으로 브로드캐스팅된다")
     void shouldSendChatMessageAsTalkType() {
         Long roomId = 1L;
+        Long userId = 1L;
+        String realNickname = "진짜닉네임";
+
         ChatMessageDto requestDto = ChatMessageDto.builder()
                 .roomId(roomId)
-                .sender("유저A")
+                .sender("방장")
                 .message("안녕하세요!")
                 .build();
 
-        chatController.sendChatMessage(roomId, requestDto);
+        SecurityUser securityUser = new SecurityUser(userId, "test@test.com");
+        Authentication auth =
+                new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities());
+
+        User user = User.builder().nickname(realNickname).build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        when(chatModerationService.filterMessage(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        chatController.sendChatMessage(roomId, requestDto, auth);
 
         // 정확한 경로(/sub/rooms/{roomId}/chat)로 메시지가 가는지 확인
         // 메시지 타입이 TALK로 설정되었는지 확인
@@ -40,6 +66,49 @@ class ChatControllerTest {
                 .convertAndSend(
                         eq("/sub/rooms/" + roomId + "/chat"),
                         argThat((ChatMessageDto dto) -> dto.getType() == ChatMessageDto.MessageType.TALK
+                                && dto.getSender().equals(realNickname)
                                 && dto.getMessage().equals("안녕하세요!")));
+    }
+
+    @Test
+    @DisplayName("빈 메시지나 공백만 있는 메시지를 보내면 브로드캐스팅되지 않는다")
+    void shouldNotSendEmptyMessage() {
+        Long roomId = 1L;
+        ChatMessageDto emptyRequest = ChatMessageDto.builder()
+                .roomId(roomId)
+                .message("   ") // 공백 메시지
+                .build();
+
+        SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
+        Authentication auth = new UsernamePasswordAuthenticationToken(securityUser, null, null);
+
+        chatController.sendChatMessage(roomId, emptyRequest, auth);
+
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("채팅 전송 시 AI 검열 서비스를 거쳐서 메시지가 나간다")
+    void shouldCallModerationService() {
+        Long roomId = 1L;
+        String raw = "욕설";
+        String filtered = "⚠️ 클린한 채팅 문화를 만들어주세요!";
+
+        ChatMessageDto requestDto = ChatMessageDto.builder().message(raw).build();
+
+        User user = User.builder().nickname("채은").build();
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(chatModerationService.filterMessage(raw)).thenReturn(filtered); // 가짜 응답
+
+        SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
+        Authentication auth = new UsernamePasswordAuthenticationToken(securityUser, null, null);
+
+        // When
+        chatController.sendChatMessage(roomId, requestDto, auth);
+
+        // Then: 최종적으로 나가는 메시지가 '필터링된 문구'인지 확인!
+        verify(messagingTemplate)
+                .convertAndSend(eq("/sub/rooms/" + roomId + "/chat"), argThat((ChatMessageDto dto) -> dto.getMessage()
+                        .equals(filtered)));
     }
 }

--- a/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
@@ -1,0 +1,53 @@
+package backend.drawrace.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatModerationServiceTest {
+
+    @Spy
+    @InjectMocks
+    private ChatModerationService chatModerationService;
+
+    @Test
+    @DisplayName("AI가 UNSAFE 판정을 내리면 메시지가 경고 문구로 바뀐다")
+    void shouldFilterUnsafeMessage() {
+        String input = "나쁜말";
+        doReturn("UNSAFE").when(chatModerationService).getAiDecision(input);
+
+        String result = chatModerationService.filterMessage(input);
+
+        assertThat(result).isEqualTo("⚠️ 클린한 채팅 문화를 만들어주세요!");
+    }
+
+    @Test
+    @DisplayName("AI가 SAFE 판정을 내리면 원문이 그대로 유지된다")
+    void shouldKeepOriginalMessageWhenSafe() {
+        String input = "안녕하세요";
+        doReturn("SAFE").when(chatModerationService).getAiDecision(input);
+
+        String result = chatModerationService.filterMessage(input);
+
+        assertThat(result).isEqualTo("안녕하세요");
+    }
+
+    @Test
+    @DisplayName("AI 서버 에러 발생 시 원문이 그대로 반환된다")
+    void shouldReturnOriginalOnFailure() {
+        // AI 서버 통신 중 예외 발생 시나리오
+        String input = "테스트";
+        doThrow(new RuntimeException("API 서버 다운")).when(chatModerationService).getAiDecision(input);
+
+        String result = chatModerationService.filterMessage(input);
+
+        assertThat(result).isEqualTo("테스트");
+    }
+}

--- a/src/test/java/backend/drawrace/domain/room/controller/WebSocketIntegrationTest.java
+++ b/src/test/java/backend/drawrace/domain/room/controller/WebSocketIntegrationTest.java
@@ -25,6 +25,12 @@ import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import backend.drawrace.domain.room.dto.response.DrawData;
+import backend.drawrace.domain.room.entity.Participant;
+import backend.drawrace.domain.room.entity.Room;
+import backend.drawrace.domain.room.repository.ParticipantRepository;
+import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.user.entity.User;
+import backend.drawrace.domain.user.repository.UserRepository;
 import backend.drawrace.global.security.JwtTokenProvider;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -36,15 +42,46 @@ public class WebSocketIntegrationTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     private WebSocketStompClient stompClient;
     private String token;
+    private User testUser;
+    private Room testRoom;
 
     @BeforeEach
     void setUp() {
-        // 테스트용 JWT 토큰 생성 (1L 유저, test@test.com)
-        token = jwtTokenProvider.createAccessToken(1L, "test@test.com");
+        // 테스트용 유저 생성
+        testUser = userRepository.save(User.builder()
+                .email("test@test.com")
+                .nickname("테스트유저")
+                .password("1234")
+                .build());
 
-        // STOMP 클라이언트 설정
+        // 테스트용 방 생성
+        testRoom = roomRepository.save(Room.builder()
+                .title("테스트방")
+                .maxPlayers((short) 4)
+                .hostId(testUser.getId())
+                .build());
+
+        // 유저를 방 참여자로 등록 (StompHandler 보안 통과용)
+        participantRepository.save(Participant.builder()
+                .userId(testUser)
+                .room(testRoom)
+                .isHost(true)
+                .build());
+
+        // 저장된 유저 ID로 토큰 생성
+        token = jwtTokenProvider.createAccessToken(testUser.getId(), testUser.getEmail());
+
         stompClient = new WebSocketStompClient(
                 new SockJsClient(List.of(new WebSocketTransport(new StandardWebSocketClient()))));
         stompClient.setMessageConverter(new MappingJackson2MessageConverter());
@@ -65,8 +102,11 @@ public class WebSocketIntegrationTest {
                 .connectAsync(url, (WebSocketHttpHeaders) null, connectHeaders, new StompSessionHandlerAdapter() {})
                 .get(5, SECONDS);
 
+        String subPath = "/sub/rooms/" + testRoom.getId() + "/draw";
+        String pubPath = "/pub/rooms/" + testRoom.getId() + "/draw";
+
         // 특정 방 구독 (/sub/rooms/1/draw)
-        session.subscribe("/sub/rooms/1/draw", new StompFrameHandler() {
+        session.subscribe(subPath, new StompFrameHandler() {
             @Override
             public Type getPayloadType(StompHeaders headers) {
                 return DrawData.class;
@@ -86,7 +126,7 @@ public class WebSocketIntegrationTest {
                 .color("#FF0000")
                 .penSize(5)
                 .build();
-        session.send("/pub/rooms/1/draw", sendData);
+        session.send(pubPath, sendData);
 
         // 전송한 데이터가 구독 경로로 다시 잘 돌아오는지 확인 (5초 대기)
         DrawData receivedData = subscribeFuture.get(5, SECONDS);

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
@@ -91,6 +92,33 @@ class RoomServiceTest {
         assertThatThrownBy(() -> roomService.joinRoom(roomId, 2L, "wrong_pw"))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("resultCode", "400-4");
+    }
+
+    @Test
+    @DisplayName("입장 시 동시성 충돌이 발생하면 최대 3번까지 재시도한다")
+    void shouldRetryWhenOptimisticLockConflictOccurs() throws Exception {
+        Long roomId = 1L;
+        Long userId = 1L;
+
+        Room room = createRoom(roomId, "테스트방", 2L);
+        User user = createUser(userId, "채은");
+
+        // 첫 번째, 두 번째 시도는 충돌 발생, 세 번째에 성공하도록 설정
+        when(roomRepository.findById(roomId)).thenReturn(Optional.of(room));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // save할 때 낙관적 락 예외를 두 번 던지게 함
+        doThrow(ObjectOptimisticLockingFailureException.class) // 1회차 실패
+                .doThrow(ObjectOptimisticLockingFailureException.class) // 2회차 실패
+                .doAnswer(invocation -> invocation.getArgument(0)) // 3회차 성공
+                .when(participantRepository)
+                .save(any());
+
+        roomService.joinRoom(roomId, userId, null);
+
+        // findById가 총 3번(최초 + 재시도 2번) 호출되었는지 확인
+        verify(roomRepository, times(3)).findById(roomId);
+        verify(participantRepository, times(3)).save(any());
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용
- 유저의 메시지를 AI가 실시간으로 분석, 부적절한 언어 감지 시 경고 문구로 자동 치환합니다.
- 방에 동시 접속 시 발생하는 정원 초과 버그를 막기 위해 낙관적 락(Optimistic Lock)을 적용하고, 충돌 시 최대 3회 자동 재시도 로직을 추가했습니다.
- StompHandler를 통해 유저가 해당 방의 참여자인지 확인 후 구독을 허용하도록 보안 로직을 강화했습니다.

## 🔢 작업 단계
- [ ] Room 엔티티에 @Version 필드 추가를 통한 낙관적 락 기반 마련
- [ ] RoomService.joinRoom 내 동시성 충돌 발생 시 자동 재시도 로직 구현
- [ ] ChatModerationService 구현 및 ChatController 연동 (AI 검열 필터)
- [ ] StompHandler 내 SUBSCRIBE 시점의 참여자 권한 검증 로직 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #37 