### PR TITLE
feat: 비밀번호 변경 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ out/
 .env
 .env.*
 !.env.example
+
+### Large data files ###
 src/main/resources/quickdraw/

--- a/src/main/java/backend/drawrace/domain/user/controller/AuthController.java
+++ b/src/main/java/backend/drawrace/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +14,7 @@ import backend.drawrace.domain.user.dto.CreateUserRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
+import backend.drawrace.domain.user.dto.UpdatePasswordRequest;
 import backend.drawrace.domain.user.service.AuthService;
 import backend.drawrace.global.rsdata.RsData;
 import backend.drawrace.global.security.SecurityUser;
@@ -48,5 +50,12 @@ public class AuthController {
     public RsData<Void> logout(@AuthenticationPrincipal SecurityUser user) {
         authService.logout(user.getUserId());
         return new RsData<>("200-3", "로그아웃되었습니다.");
+    }
+
+    @PatchMapping("/password")
+    public RsData<Void> updatePassword(
+            @AuthenticationPrincipal SecurityUser user, @RequestBody @Valid UpdatePasswordRequest request) {
+        authService.updatePassword(user.getUserId(), request);
+        return new RsData<>("200-4", "비밀번호가 변경되었습니다.");
     }
 }

--- a/src/main/java/backend/drawrace/domain/user/dto/UpdatePasswordRequest.java
+++ b/src/main/java/backend/drawrace/domain/user/dto/UpdatePasswordRequest.java
@@ -1,0 +1,21 @@
+package backend.drawrace.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdatePasswordRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다.") private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.") @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.") private String newPassword;
+}

--- a/src/main/java/backend/drawrace/domain/user/entity/User.java
+++ b/src/main/java/backend/drawrace/domain/user/entity/User.java
@@ -51,4 +51,8 @@ public class User extends BaseEntity {
         if (nickname != null) this.nickname = nickname;
         if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
     }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/backend/drawrace/domain/user/service/AuthService.java
+++ b/src/main/java/backend/drawrace/domain/user/service/AuthService.java
@@ -4,6 +4,7 @@ import backend.drawrace.domain.user.dto.CreateUserRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
+import backend.drawrace.domain.user.dto.UpdatePasswordRequest;
 
 public interface AuthService {
 
@@ -33,4 +34,11 @@ public interface AuthService {
      * @param userId 로그아웃할 유저 ID
      */
     void logout(Long userId);
+
+    /**
+     * 비밀번호 변경
+     * @param userId 변경할 유저 ID
+     * @param request 현재 비밀번호 및 새 비밀번호
+     */
+    void updatePassword(Long userId, UpdatePasswordRequest request);
 }

--- a/src/main/java/backend/drawrace/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/backend/drawrace/domain/user/service/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import backend.drawrace.domain.user.dto.CreateUserRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
+import backend.drawrace.domain.user.dto.UpdatePasswordRequest;
 import backend.drawrace.domain.user.entity.RefreshToken;
 import backend.drawrace.domain.user.entity.User;
 import backend.drawrace.domain.user.repository.RefreshTokenRepository;
@@ -100,5 +101,21 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public void logout(Long userId) {
         refreshTokenRepository.deleteById(userId);
+    }
+
+    @Override
+    @Transactional
+    public void updatePassword(Long userId, UpdatePasswordRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 유저입니다."));
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new ServiceException("401-5", "현재 비밀번호가 올바르지 않습니다.");
+        }
+
+        if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+            throw new ServiceException("400-1", "새 비밀번호가 현재 비밀번호와 동일합니다.");
+        }
+
+        user.changePassword(passwordEncoder.encode(request.getNewPassword()));
     }
 }

--- a/src/test/java/backend/drawrace/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/user/service/AuthServiceTest.java
@@ -212,7 +212,7 @@ class AuthServiceTest {
 
         // 변경된 비밀번호로 로그인 성공
         LoginResponse response = authService.login(new LoginRequest("test@example.com", "newpassword456"));
-        assertThat(response.getAccessToken()).isNotBlank();
+        assertThat(response.accessToken()).isNotBlank();
     }
 
     @Test

--- a/src/test/java/backend/drawrace/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/user/service/AuthServiceTest.java
@@ -20,6 +20,7 @@ import backend.drawrace.domain.user.dto.CreateUserRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
+import backend.drawrace.domain.user.dto.UpdatePasswordRequest;
 import backend.drawrace.domain.user.entity.RefreshToken;
 import backend.drawrace.domain.user.repository.RefreshTokenRepository;
 import backend.drawrace.global.exception.ServiceException;
@@ -193,5 +194,67 @@ class AuthServiceTest {
         authService.logout(userId);
 
         assertThat(refreshTokenRepository.findById(userId)).isEmpty();
+    }
+
+    // ===== 비밀번호 변경 =====
+
+    @Test
+    @DisplayName("비밀번호_변경_성공")
+    void updatePassword_success() {
+        Long userId = createTestUser();
+
+        authService.updatePassword(
+                userId,
+                UpdatePasswordRequest.builder()
+                        .currentPassword("password123")
+                        .newPassword("newpassword456")
+                        .build());
+
+        // 변경된 비밀번호로 로그인 성공
+        LoginResponse response = authService.login(new LoginRequest("test@example.com", "newpassword456"));
+        assertThat(response.getAccessToken()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("비밀번호_변경_실패_존재하지_않는_유저")
+    void updatePassword_fail_user_not_found() {
+        assertThatThrownBy(() -> authService.updatePassword(
+                        999L,
+                        UpdatePasswordRequest.builder()
+                                .currentPassword("password123")
+                                .newPassword("newpassword456")
+                                .build()))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "404-1");
+    }
+
+    @Test
+    @DisplayName("비밀번호_변경_실패_현재_비밀번호_불일치")
+    void updatePassword_fail_wrong_current_password() {
+        Long userId = createTestUser();
+
+        assertThatThrownBy(() -> authService.updatePassword(
+                        userId,
+                        UpdatePasswordRequest.builder()
+                                .currentPassword("wrongpassword")
+                                .newPassword("newpassword456")
+                                .build()))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "401-5");
+    }
+
+    @Test
+    @DisplayName("비밀번호_변경_실패_새_비밀번호가_현재와_동일")
+    void updatePassword_fail_same_password() {
+        Long userId = createTestUser();
+
+        assertThatThrownBy(() -> authService.updatePassword(
+                        userId,
+                        UpdatePasswordRequest.builder()
+                                .currentPassword("password123")
+                                .newPassword("password123")
+                                .build()))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "400-1");
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

- PATCH /api/auth/password 엔드포인트 추가
- 현재 비밀번호 검증 및 동일 비밀번호 변경 방지 로직 구현
- UpdatePasswordRequest DTO 추가
- AuthServiceTest에 비밀번호 변경 테스트 4케이스 추가
- .gitignore에 .env 및 quickdraw 데이터 디렉토리 추가

## 🔢 작업 단계
- [ ] 

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #