### PR TITLE
Feature: ai 유저 챗 구현

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/service/AiChatService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/AiChatService.java
@@ -1,0 +1,119 @@
+package backend.drawrace.domain.chat.service;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
+import backend.drawrace.domain.round.dto.gateway.GatewayChatRequest;
+import backend.drawrace.domain.round.dto.gateway.GatewayChatResponse;
+import backend.drawrace.global.config.AiProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "ai.mode", havingValue = "quickdraw")
+@RequiredArgsConstructor
+public class AiChatService {
+
+    private static final long CHAT_DELAY_MIN_MS = 2_000L;
+    private static final long CHAT_DELAY_MAX_MS = 5_000L;
+
+    private final AiProperties aiProperties;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Async
+    public void triggerOnRoundStart(Long roomId, String keyword, String aiNickname) {
+        try {
+            sleep();
+            String message = generateChatMessage(buildRoundStartPrompt(keyword));
+            broadcast(roomId, aiNickname, message);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.warn("AI 채팅 생성 실패 (라운드 시작). roomId={}", roomId, e);
+        }
+    }
+
+    @Async
+    public void triggerOnRoundEnd(Long roomId, String keyword, String aiNickname, boolean aiIsWinner) {
+        try {
+            sleep();
+            String message = generateChatMessage(buildRoundEndPrompt(keyword, aiIsWinner));
+            broadcast(roomId, aiNickname, message);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.warn("AI 채팅 생성 실패 (라운드 종료). roomId={}", roomId, e);
+        }
+    }
+
+    private void sleep() throws InterruptedException {
+        long delay = ThreadLocalRandom.current().nextLong(CHAT_DELAY_MIN_MS, CHAT_DELAY_MAX_MS + 1);
+        Thread.sleep(delay);
+    }
+
+    private String generateChatMessage(String systemPrompt) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(aiProperties.baseUrl())
+                .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey())
+                .build();
+
+        GatewayChatRequest request = GatewayChatRequest.builder()
+                .model(aiProperties.model())
+                .messages(List.of(GatewayChatRequest.systemMessage(systemPrompt)))
+                .temperature(0.8)
+                .build();
+
+        GatewayChatResponse response = restClient
+                .post()
+                .uri("/chat/completions")
+                .body(request)
+                .retrieve()
+                .toEntity(GatewayChatResponse.class)
+                .getBody();
+
+        return response.getChoices().get(0).getMessage().getContent().trim();
+    }
+
+    private String buildRoundStartPrompt(String keyword) {
+        return String.format(
+                """
+                너는 그림 맞추기 게임에 참가한 AI 플레이어야.
+                지금 라운드의 제시어는 '%s'야.
+                게임 참가자로서 자연스럽고 짧은 한국어 채팅 메시지를 한 문장으로 만들어줘.
+                그림 그리기 시작에 어울리는 말이어야 해.
+                이모지 포함 가능. 말투는 친근하게. 반드시 한 문장만 출력해.
+                """,
+                keyword);
+    }
+
+    private String buildRoundEndPrompt(String keyword, boolean aiIsWinner) {
+        String context = aiIsWinner ? "이번 라운드에서 내가 이겼어" : "이번 라운드에서 내가 졌어";
+        return String.format(
+                """
+                너는 그림 맞추기 게임에 참가한 AI 플레이어야.
+                제시어는 '%s'였고, %s.
+                게임 참가자로서 자연스럽고 짧은 한국어 채팅 메시지를 한 문장으로 만들어줘.
+                이모지 포함 가능. 말투는 친근하게. 반드시 한 문장만 출력해.
+                """,
+                keyword, context);
+    }
+
+    private void broadcast(Long roomId, String aiNickname, String message) {
+        ChatMessageDto chatMessage = ChatMessageDto.builder()
+                .type(ChatMessageDto.MessageType.TALK)
+                .roomId(roomId)
+                .sender(aiNickname)
+                .message(message)
+                .build();
+        messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);
+    }
+}

--- a/src/main/java/backend/drawrace/domain/chat/service/AiChatService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/AiChatService.java
@@ -30,6 +30,19 @@ public class AiChatService {
     private final SimpMessagingTemplate messagingTemplate;
 
     @Async
+    public void triggerOnAiJoin(Long roomId, String aiNickname) {
+        try {
+            sleep();
+            String message = generateChatMessage(buildJoinPrompt());
+            broadcast(roomId, aiNickname, message);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.warn("AI 채팅 생성 실패 (입장). roomId={}", roomId, e);
+        }
+    }
+
+    @Async
     public void triggerOnRoundStart(Long roomId, String keyword, String aiNickname) {
         try {
             sleep();
@@ -81,6 +94,14 @@ public class AiChatService {
                 .getBody();
 
         return response.getChoices().get(0).getMessage().getContent().trim();
+    }
+
+    private String buildJoinPrompt() {
+        return """
+                너는 그림 맞추기 게임에 참가한 AI 플레이어야.
+                방에 막 입장했어. 자연스럽고 짧은 한국어 인삿말을 한 문장으로 만들어줘.
+                이모지 포함 가능. 말투는 친근하게. 반드시 한 문장만 출력해.
+                """;
     }
 
     private String buildRoundStartPrompt(String keyword) {

--- a/src/main/java/backend/drawrace/domain/chat/service/AiChatService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/AiChatService.java
@@ -105,27 +105,23 @@ public class AiChatService {
     }
 
     private String buildRoundStartPrompt(String keyword) {
-        return String.format(
-                """
+        return String.format("""
                 너는 그림 맞추기 게임에 참가한 AI 플레이어야.
                 지금 라운드의 제시어는 '%s'야.
                 게임 참가자로서 자연스럽고 짧은 한국어 채팅 메시지를 한 문장으로 만들어줘.
                 그림 그리기 시작에 어울리는 말이어야 해.
                 이모지 포함 가능. 말투는 친근하게. 반드시 한 문장만 출력해.
-                """,
-                keyword);
+                """, keyword);
     }
 
     private String buildRoundEndPrompt(String keyword, boolean aiIsWinner) {
         String context = aiIsWinner ? "이번 라운드에서 내가 이겼어" : "이번 라운드에서 내가 졌어";
-        return String.format(
-                """
+        return String.format("""
                 너는 그림 맞추기 게임에 참가한 AI 플레이어야.
                 제시어는 '%s'였고, %s.
                 게임 참가자로서 자연스럽고 짧은 한국어 채팅 메시지를 한 문장으로 만들어줘.
                 이모지 포함 가능. 말투는 친근하게. 반드시 한 문장만 출력해.
-                """,
-                keyword, context);
+                """, keyword, context);
     }
 
     private void broadcast(Long roomId, String aiNickname, String message) {

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -4,12 +4,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
+import backend.drawrace.domain.chat.service.AiChatService;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
@@ -35,6 +37,7 @@ public class RoomService {
     private final UserRepository userRepository;
     private final RankingService rankingService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectProvider<AiChatService> aiChatServiceProvider;
 
     @Transactional
     public RoomInfoRes createRoom(CreateRoomReq req, Long userId) {
@@ -204,6 +207,11 @@ public class RoomService {
 
         participantRepository.save(aiParticipant);
         room.addParticipant(aiParticipant);
+
+        AiChatService aiChatService = aiChatServiceProvider.getIfAvailable();
+        if (aiChatService != null) {
+            aiChatService.triggerOnAiJoin(roomId, aiUser.getNickname());
+        }
 
         return getRoomDetail(roomId);
     }

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -478,7 +478,8 @@ public class RoundService {
         participants.stream()
                 .filter(p -> p.getUserId().isAi())
                 .findFirst()
-                .ifPresent(ai -> service.triggerOnRoundStart(roomId, keyword, ai.getUserId().getNickname()));
+                .ifPresent(ai -> service.triggerOnRoundStart(
+                        roomId, keyword, ai.getUserId().getNickname()));
     }
 
     private void triggerAiChatOnRoundEnd(

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
+import backend.drawrace.domain.chat.service.AiChatService;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
@@ -48,6 +49,7 @@ public class RoundService {
     private final AiInferenceService aiInferenceService;
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
+    private final ObjectProvider<AiChatService> aiChatServiceProvider;
 
     /**
      * 게임 시작 처리
@@ -74,6 +76,7 @@ public class RoundService {
         List<Participant> participants = participantRepository.findByRoomId(roomId);
         saveRoundParticipants(savedRound, participants);
         triggerAiIfPresent(savedRound, participants);
+        triggerAiChatOnRoundStart(roomId, keyword, participants);
 
         RoundStartResponse response = RoundStartResponse.from(savedRound);
 
@@ -249,6 +252,8 @@ public class RoundService {
                 .message("라운드 승리자: " + winnerNickname + "님! 축하합니다.")
                 .build();
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", winnerNotice);
+
+        triggerAiChatOnRoundEnd(roomId, round.getKeyword(), submissions, roundWinner);
 
         return handleAfterRoundFinished(
                 round, submittedAiResult, winnerSubmission, submittedCount, totalParticipantCount, roundWinner);
@@ -464,6 +469,31 @@ public class RoundService {
                 .build();
 
         messagingTemplate.convertAndSend("/sub/rooms/" + round.getRoom().getId(), event);
+    }
+
+    private void triggerAiChatOnRoundStart(Long roomId, String keyword, List<Participant> participants) {
+        AiChatService service = aiChatServiceProvider.getIfAvailable();
+        if (service == null) return;
+
+        participants.stream()
+                .filter(p -> p.getUserId().isAi())
+                .findFirst()
+                .ifPresent(ai -> service.triggerOnRoundStart(roomId, keyword, ai.getUserId().getNickname()));
+    }
+
+    private void triggerAiChatOnRoundEnd(
+            Long roomId, String keyword, List<RoundSubmission> submissions, Participant roundWinner) {
+        AiChatService service = aiChatServiceProvider.getIfAvailable();
+        if (service == null) return;
+
+        submissions.stream()
+                .map(RoundSubmission::getParticipant)
+                .filter(p -> p.getUserId().isAi())
+                .findFirst()
+                .ifPresent(ai -> {
+                    boolean aiIsWinner = ai.getId().equals(roundWinner.getId());
+                    service.triggerOnRoundEnd(roomId, keyword, ai.getUserId().getNickname(), aiIsWinner);
+                });
     }
 
     private void sendFinalWinnerNotice(Long roomId, String nickname) {


### PR DESCRIPTION
## 📝 작업 내용
-  AI 유저가 게임 진행 중 상황에 맞는 채팅을 자동으로 보내는 기능 구현. 
-  GLM 게이트웨이를 통해 메시지를 생성하고 WebSocket으로 브로드캐스트.  

## 🔢 작업 단계
- [ ] AiChatService 생성
- [ ] 트리거 3종 구현 (triggerOnAiJoin, triggerOnRoundStart, triggerOnRoundStart)
- [ ] RoomService 연동
- [ ] RoundService 연동

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #49