### PR TITLE
Feature: 게스트 닉네임 자동 생성 (glm)

### DIFF
--- a/src/main/java/backend/drawrace/domain/user/controller/AuthController.java
+++ b/src/main/java/backend/drawrace/domain/user/controller/AuthController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import backend.drawrace.domain.user.dto.CreateUserRequest;
-import backend.drawrace.domain.user.dto.GuestLoginRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
@@ -54,8 +53,8 @@ public class AuthController {
     }
 
     @PostMapping("/guest")
-    public RsData<LoginResponse> guestLogin(@RequestBody @Valid GuestLoginRequest request) {
-        LoginResponse token = authService.guestLogin(request);
+    public RsData<LoginResponse> guestLogin() {
+        LoginResponse token = authService.guestLogin();
         return new RsData<>("201-2", "게스트 로그인에 성공했습니다.", token);
     }
 

--- a/src/main/java/backend/drawrace/domain/user/dto/GuestLoginRequest.java
+++ b/src/main/java/backend/drawrace/domain/user/dto/GuestLoginRequest.java
@@ -1,8 +1,0 @@
-package backend.drawrace.domain.user.dto;
-
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-
-public record GuestLoginRequest(
-        @NotBlank(message = "닉네임은 필수입니다.") @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.") @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "닉네임은 한글, 영문, 숫자만 가능합니다.") String nickname) {}

--- a/src/main/java/backend/drawrace/domain/user/service/AuthService.java
+++ b/src/main/java/backend/drawrace/domain/user/service/AuthService.java
@@ -1,7 +1,6 @@
 package backend.drawrace.domain.user.service;
 
 import backend.drawrace.domain.user.dto.CreateUserRequest;
-import backend.drawrace.domain.user.dto.GuestLoginRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
@@ -44,9 +43,8 @@ public interface AuthService {
     void updatePassword(Long userId, UpdatePasswordRequest request);
 
     /**
-     * 게스트 로그인 (닉네임만으로 임시 계정 생성 후 단기 토큰 발급)
-     * @param request 닉네임
+     * 게스트 로그인 (GLM이 닉네임을 자동 생성해 임시 계정을 만들고 단기 토큰 발급)
      * @return 단기 AccessToken (RefreshToken 없음)
      */
-    LoginResponse guestLogin(GuestLoginRequest request);
+    LoginResponse guestLogin();
 }

--- a/src/main/java/backend/drawrace/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/backend/drawrace/domain/user/service/AuthServiceImpl.java
@@ -1,13 +1,13 @@
 package backend.drawrace.domain.user.service;
 
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import backend.drawrace.domain.user.dto.CreateUserRequest;
-import backend.drawrace.domain.user.dto.GuestLoginRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
@@ -30,6 +30,7 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final GuestNicknameGenerator nicknameGenerator;
 
     @Override
     @Transactional
@@ -112,8 +113,8 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public LoginResponse guestLogin(GuestLoginRequest request) {
-        String nickname = resolveGuestNickname(request.nickname());
+    public LoginResponse guestLogin() {
+        String nickname = resolveNickname(nicknameGenerator.generate());
 
         User guest = User.builder()
                 .email("guest_" + UUID.randomUUID() + "@drawrace.com")
@@ -129,15 +130,14 @@ public class AuthServiceImpl implements AuthService {
         return new LoginResponse(accessToken, "");
     }
 
-    private String resolveGuestNickname(String base) {
-        if (!userRepository.existsByNickname(base)) {
-            return base;
-        }
-        int suffix = 1;
-        while (userRepository.existsByNickname(base + "_" + suffix)) {
-            suffix++;
-        }
-        return base + "_" + suffix;
+    private String resolveNickname(String base) {
+        if (!userRepository.existsByNickname(base)) return base;
+        String candidate;
+        do {
+            int suffix = ThreadLocalRandom.current().nextInt(1000, 10000);
+            candidate = base + "_" + suffix;
+        } while (userRepository.existsByNickname(candidate));
+        return candidate;
     }
 
     @Override

--- a/src/main/java/backend/drawrace/domain/user/service/GuestNicknameGenerator.java
+++ b/src/main/java/backend/drawrace/domain/user/service/GuestNicknameGenerator.java
@@ -1,0 +1,91 @@
+package backend.drawrace.domain.user.service;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import backend.drawrace.domain.round.dto.gateway.GatewayChatRequest;
+import backend.drawrace.domain.round.dto.gateway.GatewayChatResponse;
+import backend.drawrace.global.config.AiProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GuestNicknameGenerator {
+
+    private final AiProperties aiProperties;
+
+    private static final List<String> FALLBACK_NICKNAMES = List.of(
+            "익명토끼", "낙서꾼", "그림왕", "붓질러", "색칠왕",
+            "몽상가", "도화지", "크레파스", "물감쟁이", "연필깎이");
+
+    public String generate() {
+        try {
+            RestClient restClient = RestClient.builder()
+                    .baseUrl(aiProperties.baseUrl())
+                    .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey())
+                    .build();
+
+            GatewayChatRequest request = GatewayChatRequest.builder()
+                    .model(aiProperties.model())
+                    .temperature(1.0)
+                    .messages(List.of(
+                            GatewayChatRequest.systemMessage(buildSystemPrompt()),
+                            GatewayChatRequest.userMessage("게스트 닉네임 하나 생성해줘.")))
+                    .build();
+
+            GatewayChatResponse response = restClient
+                    .post()
+                    .uri("/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(GatewayChatResponse.class);
+
+            String nickname = extractNickname(response);
+            if (nickname.isBlank()) {
+                log.warn("GLM 닉네임 응답이 비어 있어 fallback 사용");
+                return getFallback();
+            }
+            return nickname;
+        } catch (Exception e) {
+            log.warn("GLM 닉네임 생성 실패, fallback 사용", e);
+            return getFallback();
+        }
+    }
+
+    private String buildSystemPrompt() {
+        return """
+                너는 그림 그리기 게임의 게스트 닉네임 생성기다.
+                조건:
+                - 한국어로 2~6글자
+                - 귀엽거나 재미있는 느낌의 명사 또는 형용사+명사 조합
+                - 욕설, 비방, 성적 표현 금지
+                - 닉네임 1개만 반환하고 설명, 따옴표, 번호, 부가 문장 없이 출력
+                """;
+    }
+
+    private String extractNickname(GatewayChatResponse response) {
+        if (response == null
+                || response.getChoices() == null
+                || response.getChoices().isEmpty()
+                || response.getChoices().get(0).getMessage() == null) {
+            return "";
+        }
+        String content = response.getChoices().get(0).getMessage().getContent();
+        if (content == null) return "";
+        return content.trim()
+                .replace("\"", "")
+                .replace("'", "")
+                .replaceAll("\\s+", "")
+                .replaceAll("[^가-힣a-zA-Z0-9]", "");
+    }
+
+    private String getFallback() {
+        return FALLBACK_NICKNAMES.get(ThreadLocalRandom.current().nextInt(FALLBACK_NICKNAMES.size()));
+    }
+}

--- a/src/main/java/backend/drawrace/domain/user/service/GuestNicknameGenerator.java
+++ b/src/main/java/backend/drawrace/domain/user/service/GuestNicknameGenerator.java
@@ -20,9 +20,8 @@ public class GuestNicknameGenerator {
 
     private final AiProperties aiProperties;
 
-    private static final List<String> FALLBACK_NICKNAMES = List.of(
-            "익명토끼", "낙서꾼", "그림왕", "붓질러", "색칠왕",
-            "몽상가", "도화지", "크레파스", "물감쟁이", "연필깎이");
+    private static final List<String> FALLBACK_NICKNAMES =
+            List.of("익명토끼", "낙서꾼", "그림왕", "붓질러", "색칠왕", "몽상가", "도화지", "크레파스", "물감쟁이", "연필깎이");
 
     public String generate() {
         try {

--- a/src/test/java/backend/drawrace/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/user/service/AuthServiceTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import backend.drawrace.domain.user.dto.CreateUserRequest;
-import backend.drawrace.domain.user.dto.GuestLoginRequest;
 import backend.drawrace.domain.user.dto.LoginRequest;
 import backend.drawrace.domain.user.dto.LoginResponse;
 import backend.drawrace.domain.user.dto.TokenRequest;
@@ -36,6 +35,9 @@ class AuthServiceTest {
     @MockBean
     // @Autowired
     RefreshTokenRepository refreshTokenRepository;
+
+    @MockBean
+    GuestNicknameGenerator nicknameGenerator;
 
     @AfterEach
     void tearDown() {
@@ -202,7 +204,9 @@ class AuthServiceTest {
     @Test
     @DisplayName("게스트_로그인_성공")
     void guestLogin_success() {
-        LoginResponse response = authService.guestLogin(new GuestLoginRequest("게스트닉네임"));
+        given(nicknameGenerator.generate()).willReturn("게스트닉네임");
+
+        LoginResponse response = authService.guestLogin();
 
         assertThat(response.accessToken()).isNotBlank();
         assertThat(response.refreshToken()).isEmpty();
@@ -211,8 +215,10 @@ class AuthServiceTest {
     @Test
     @DisplayName("게스트_로그인_성공_닉네임_중복_시_suffix_부여")
     void guestLogin_success_duplicate_nickname_gets_suffix() {
-        authService.guestLogin(new GuestLoginRequest("홍길동"));
-        LoginResponse response = authService.guestLogin(new GuestLoginRequest("홍길동"));
+        given(nicknameGenerator.generate()).willReturn("홍길동");
+
+        authService.guestLogin();
+        LoginResponse response = authService.guestLogin();
 
         assertThat(response.accessToken()).isNotBlank();
     }
@@ -221,8 +227,9 @@ class AuthServiceTest {
     @DisplayName("게스트_로그인_성공_회원_닉네임과_중복_시_suffix_부여")
     void guestLogin_success_member_nickname_conflict_gets_suffix() {
         createTestUser(); // 닉네임: 테스터
+        given(nicknameGenerator.generate()).willReturn("테스터");
 
-        LoginResponse response = authService.guestLogin(new GuestLoginRequest("테스터"));
+        LoginResponse response = authService.guestLogin();
 
         assertThat(response.accessToken()).isNotBlank();
     }

--- a/src/test/java/backend/drawrace/domain/user/service/UserServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/user/service/UserServiceTest.java
@@ -2,16 +2,14 @@ package backend.drawrace.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import static org.mockito.BDDMockito.given;
+import org.springframework.transaction.annotation.Transactional;
 
 import backend.drawrace.domain.user.dto.CreateUserRequest;
 import backend.drawrace.domain.user.dto.UpdateUserRequest;

--- a/src/test/java/backend/drawrace/domain/user/service/UserServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/user/service/UserServiceTest.java
@@ -9,8 +9,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.BDDMockito.given;
+
 import backend.drawrace.domain.user.dto.CreateUserRequest;
-import backend.drawrace.domain.user.dto.GuestLoginRequest;
 import backend.drawrace.domain.user.dto.UpdateUserRequest;
 import backend.drawrace.domain.user.dto.UserInfoResponse;
 import backend.drawrace.domain.user.dto.UserSearchResponse;
@@ -25,6 +28,9 @@ class UserServiceTest {
 
     @Autowired
     AuthService authService;
+
+    @MockBean
+    GuestNicknameGenerator nicknameGenerator;
 
     private Long createTestUser() {
         return authService.signup(new CreateUserRequest("test@example.com", "password123", "테스터"));
@@ -158,7 +164,8 @@ class UserServiceTest {
     @Test
     @DisplayName("게스트_프로필_수정_실패")
     void updateProfile_fail_guest() {
-        authService.guestLogin(new GuestLoginRequest("게스트테스터"));
+        given(nicknameGenerator.generate()).willReturn("게스트테스터");
+        authService.guestLogin();
         Long guestId = userService.searchByNickname("게스트테스터").id();
 
         assertThatThrownBy(() -> userService.updateProfile(guestId, new UpdateUserRequest("새닉네임", null)))


### PR DESCRIPTION
## 📝 작업 내용
- glm이  게스트 닉네임을 자동 생성하도록 기능을 수정한다.

## 🔢 작업 단계
- [ ]  GuestNicknameGenerator : GLM 호출해서 한국어 닉네임 생성, 실패 시 fallback 10개 중 랜덤 반환
- [ ] AuthService : guestLogin(GuestLoginRequest) → guestLogin()
- [ ] AuthServiceTest / UserServiceTest : @MockBean GuestNicknameGenerator로 mock 처리

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #