### PR TITLE
feat: 로컬 스토리지 기반 프로필 이미지 업로드 기능 추가 및 보완

### DIFF
--- a/src/main/java/backend/drawrace/domain/user/dto/UpdateUserRequest.java
+++ b/src/main/java/backend/drawrace/domain/user/dto/UpdateUserRequest.java
@@ -4,6 +4,4 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record UpdateUserRequest(
-        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.") @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "닉네임은 한글, 영문, 숫자만 가능합니다.") String nickname,
-
-        String profileImageUrl) {}
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.") @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "닉네임은 한글, 영문, 숫자만 가능합니다.") String nickname) {}

--- a/src/main/java/backend/drawrace/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/backend/drawrace/domain/user/service/UserServiceImpl.java
@@ -63,7 +63,7 @@ public class UserServiceImpl implements UserService {
             throw new ServiceException("409-1", "이미 사용 중인 닉네임입니다.");
         }
 
-        user.updateProfile(request.nickname(), request.profileImageUrl());
+        user.updateProfile(request.nickname(), null);
         return UserInfoResponse.from(user);
     }
 
@@ -90,10 +90,13 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void deleteUser(Long userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new ServiceException("404-1", "존재하지 않는 유저입니다. ID: " + userId);
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 유저입니다. ID: " + userId));
+        if (user.getProfileImageUrl() != null) {
+            fileStorageService.delete(user.getProfileImageUrl());
         }
         refreshTokenRepository.deleteById(userId);
-        userRepository.deleteById(userId);
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/backend/drawrace/global/security/SecurityConfig.java
+++ b/src/main/java/backend/drawrace/global/security/SecurityConfig.java
@@ -42,6 +42,8 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                         .permitAll()
+                        .requestMatchers("/files/uploads/**")
+                        .permitAll()
                         // 웹소켓 연결 시작 주소는 허용 (인증은 인터셉터에서 수행)
                         .requestMatchers("/ws-draw/**")
                         .permitAll()

--- a/src/main/java/backend/drawrace/global/storage/LocalFileStorageService.java
+++ b/src/main/java/backend/drawrace/global/storage/LocalFileStorageService.java
@@ -29,6 +29,10 @@ public class LocalFileStorageService implements FileStorageService {
 
     @Override
     public String store(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new ServiceException("400-2", "파일이 비어 있습니다.");
+        }
+
         String ext = extractExtension(file.getOriginalFilename());
         if (!ALLOWED_EXTENSIONS.contains(ext.toLowerCase())) {
             throw new ServiceException("400-2", "허용되지 않는 파일 형식입니다. (jpg, jpeg, png, gif, webp)");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   config:
     import: optional:file:.env[.properties]
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
   output:
     ansi:
       enabled: ALWAYS

--- a/src/test/java/backend/drawrace/domain/user/service/UserServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/user/service/UserServiceTest.java
@@ -94,44 +94,19 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("프로필_수정_성공_닉네임만_변경")
+    @DisplayName("프로필_수정_성공_닉네임_변경")
     void updateProfile_success_nickname_only() {
         Long savedId = createTestUser();
 
-        UserInfoResponse response = userService.updateProfile(savedId, new UpdateUserRequest("새닉네임", null));
+        UserInfoResponse response = userService.updateProfile(savedId, new UpdateUserRequest("새닉네임"));
 
         assertThat(response.nickname()).isEqualTo("새닉네임");
-        assertThat(response.profileImageUrl()).isNull();
-    }
-
-    @Test
-    @DisplayName("프로필_수정_성공_프로필이미지만_변경")
-    void updateProfile_success_profileImage_only() {
-        Long savedId = createTestUser();
-
-        UserInfoResponse response =
-                userService.updateProfile(savedId, new UpdateUserRequest(null, "https://example.com/image.png"));
-
-        assertThat(response.nickname()).isEqualTo("테스터");
-        assertThat(response.profileImageUrl()).isEqualTo("https://example.com/image.png");
-    }
-
-    @Test
-    @DisplayName("프로필_수정_성공_닉네임_프로필이미지_모두_변경")
-    void updateProfile_success_all_fields() {
-        Long savedId = createTestUser();
-
-        UserInfoResponse response =
-                userService.updateProfile(savedId, new UpdateUserRequest("새닉네임", "https://example.com/image.png"));
-
-        assertThat(response.nickname()).isEqualTo("새닉네임");
-        assertThat(response.profileImageUrl()).isEqualTo("https://example.com/image.png");
     }
 
     @Test
     @DisplayName("프로필_수정_실패_존재하지_않는_유저")
     void updateProfile_fail_not_found() {
-        assertThatThrownBy(() -> userService.updateProfile(999L, new UpdateUserRequest("새닉네임", null)))
+        assertThatThrownBy(() -> userService.updateProfile(999L, new UpdateUserRequest("새닉네임")))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("resultCode", "404-1");
     }
@@ -142,7 +117,7 @@ class UserServiceTest {
         Long savedId = createTestUser();
         authService.signup(new CreateUserRequest("other@example.com", "password123", "다른유저"));
 
-        assertThatThrownBy(() -> userService.updateProfile(savedId, new UpdateUserRequest("다른유저", null)))
+        assertThatThrownBy(() -> userService.updateProfile(savedId, new UpdateUserRequest("다른유저")))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("resultCode", "409-1");
     }
@@ -152,7 +127,7 @@ class UserServiceTest {
     void updateProfile_success_same_nickname() {
         Long savedId = createTestUser();
 
-        UserInfoResponse response = userService.updateProfile(savedId, new UpdateUserRequest("테스터", null));
+        UserInfoResponse response = userService.updateProfile(savedId, new UpdateUserRequest("테스터"));
 
         assertThat(response.nickname()).isEqualTo("테스터");
     }
@@ -166,7 +141,7 @@ class UserServiceTest {
         authService.guestLogin();
         Long guestId = userService.searchByNickname("게스트테스터").id();
 
-        assertThatThrownBy(() -> userService.updateProfile(guestId, new UpdateUserRequest("새닉네임", null)))
+        assertThatThrownBy(() -> userService.updateProfile(guestId, new UpdateUserRequest("새닉네임")))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("resultCode", "403-4");
     }


### PR DESCRIPTION
## 📝 작업 내용
- 프로필 이미지 업로드 기능 추가 후 누락된 보안·유효성 처리 보완

## 🔢 작업 단계
- [ ] SecurityConfig: /files/uploads/** permitAll 추가
- [ ] application.yml: multipart 10MB 제한 추가
- [ ] UpdateUserRequest: profileImageUrl 필드 제거 
- [ ] UserServiceImpl: deleteUser() 시 프로필 이미지 파일 함께 삭제, existsById 중복 체크 제거
- [ ] LocalFileStorageService: 빈 파일(file.isEmpty()) 체크 추가
- [ ] UserServiceTest: UpdateUserRequest 변경에 맞게 테스트 수정

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #