### PR TITLE
[Refactor] chat도메인 및 room도메인 로직 고도화

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
+++ b/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
@@ -39,7 +39,8 @@ public class ChatController {
                 .orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
 
         // AI 검열 실행
-        String filteredMessage = chatModerationService.filterMessage(chatMessage.getMessage());
+        String filteredMessage =
+                chatModerationService.filterMessage(securityUser.getUserId(), chatMessage.getMessage());
 
         chatMessage.setSender(user.getNickname());
         chatMessage.setMessage(filteredMessage);

--- a/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
@@ -1,6 +1,8 @@
 package backend.drawrace.domain.chat.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -8,6 +10,7 @@ import org.springframework.web.client.RestClient;
 import backend.drawrace.domain.round.dto.gateway.GatewayChatRequest;
 import backend.drawrace.domain.round.dto.gateway.GatewayChatResponse;
 import backend.drawrace.global.config.AiProperties;
+import backend.drawrace.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,19 +22,26 @@ public class ChatModerationService {
 
     private final AiProperties aiProperties;
 
-    public String filterMessage(String originalMessage) {
+    private final Map<Long, LastChatInfo> chatHistory = new ConcurrentHashMap<>();
+    private static final int SPAM_LIMIT_MS = 1000;
+
+    public String filterMessage(Long userId, String originalMessage) {
         try {
+            // 도배 체크
+            checkSpam(userId, originalMessage);
+
             // 분리된 메서드 호출
             String aiDecision = getAiDecision(originalMessage);
 
-            if (aiDecision.contains("UNSAFE")) {
-                return "⚠️ 클린한 채팅 문화를 만들어주세요!";
-            }
+            // AI 판정 결과
+            return aiDecision;
+
+        } catch (ServiceException e) {
+            throw e;
         } catch (Exception e) {
             log.error("AI 검열 중 오류 발생: {}", e.getMessage());
             return originalMessage;
         }
-        return originalMessage;
     }
 
     protected String getAiDecision(String message) {
@@ -42,11 +52,36 @@ public class ChatModerationService {
 
         // 프롬프트
         String systemPrompt = """
-            너는 실시간 게임의 채팅 검열관이야.
-            사용자의 메시지가 욕설, 비방, 성적인 내용, 혹은 부적절한 언어를 포함하고 있는지 판단해.
-            부적절하다면 무조건 'UNSAFE'라고만 답하고,
-            괜찮다면 'SAFE'라고만 답해.
-            설명이나 다른 말은 절대 하지 마.
+                [기본 원칙]
+                당신은 유저가 그린 그림을 AI가 판별하는 게임 'DrawRace'의 커뮤니티 관리자입니다. 유저들은 AI의 판별 결과에 따라 순위 경쟁을 하고 있습니다. 아래 기준에 따라 부적절한 메시지의 해당 부분만 ****로 치환하세요.
+
+                [상세 검열 기준]
+                1. 비속어 및 공격적 언어 (Profanity & Aggression)
+
+                - 직접적인 욕설, 패드립, 타인에 대한 비하 발언.
+
+                - 변형된 욕설 및 초성 욕설 (예: 'ㅅㅂ', 'ㄲㅈ' 등).
+
+                2. 유저 간 비난 및 도발 (Competitive Toxicity)
+
+                - 레이스 중 다른 참가자의 그림 실력을 심하게 비하하거나 조롱하여 불쾌감을 주는 행위.
+
+                - (예: "와 님 손은 장식임? 진짜 드럽게 못 그리네" -> "와 님 손은 장식임? 진짜 **** 그리네")
+
+                3. 성적 콘텐츠 및 혐오 표현 (Sexual & Hate Speech)
+
+                - 음란한 표현, 성희롱, 특정 집단(성별, 지역 등)에 대한 혐오 발언.
+
+                4. 도배 및 스팸 (Spamming)
+
+                - 의미 없는 문자의 반복, 홍보성 문구 등 게임 진행을 방해하는 채팅.
+
+                [출력 규칙]
+                - 필터링된 결과값만 출력 (설명이나 인사말 절대 금지).
+
+                - 금지 단어에 해당하는 부분만 정확히 ****로 치환.
+
+                - 해당하는 위반 사항이 전혀 없으면 유저의 원문을 토씨 하나 안 틀리고 그대로 출력.
             """;
 
         GatewayChatRequest request = GatewayChatRequest.builder()
@@ -66,4 +101,17 @@ public class ChatModerationService {
 
         return response.getChoices().get(0).getMessage().getContent().trim();
     }
+
+    private void checkSpam(Long userId, String message) {
+        long now = System.currentTimeMillis();
+        LastChatInfo last = chatHistory.get(userId);
+
+        if (last != null) {
+            if (now - last.timestamp < SPAM_LIMIT_MS) throw new ServiceException("429-1", "채팅이 너무 빠릅니다.");
+            if (last.message.equals(message)) throw new ServiceException("429-2", "동일한 메시지 반복 금지.");
+        }
+        chatHistory.put(userId, new LastChatInfo(message, now));
+    }
+
+    private record LastChatInfo(String message, long timestamp) {}
 }

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -49,7 +49,7 @@ public class RoomService {
                 .password(req.password())
                 .hostId(userId)
                 .totalRounds(req.totalRounds())
-                .maxPlayers((short) 4)
+                .maxPlayers(req.maxPlayers())
                 .build();
 
         roomRepository.save(room);

--- a/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
@@ -56,7 +56,8 @@ class ChatControllerTest {
         User user = User.builder().nickname(realNickname).build();
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        when(chatModerationService.filterMessage(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chatModerationService.filterMessage(anyLong(), anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
 
         chatController.sendChatMessage(roomId, requestDto, auth);
 
@@ -96,9 +97,9 @@ class ChatControllerTest {
 
         ChatMessageDto requestDto = ChatMessageDto.builder().message(raw).build();
 
-        User user = User.builder().nickname("채은").build();
+        User user = User.builder().nickname("유저A").build();
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
-        when(chatModerationService.filterMessage(raw)).thenReturn(filtered); // 가짜 응답
+        when(chatModerationService.filterMessage(anyLong(), eq(raw))).thenReturn(filtered); // 가짜 응답
 
         SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
         Authentication auth = new UsernamePasswordAuthenticationToken(securityUser, null, null);

--- a/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
@@ -7,36 +7,33 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import backend.drawrace.global.config.AiProperties;
+
 @ExtendWith(MockitoExtension.class)
 class ChatModerationServiceTest {
+
+    @Mock
+    private AiProperties aiProperties;
 
     @Spy
     @InjectMocks
     private ChatModerationService chatModerationService;
 
     @Test
-    @DisplayName("AI가 UNSAFE 판정을 내리면 메시지가 경고 문구로 바뀐다")
-    void shouldFilterUnsafeMessage() {
-        String input = "나쁜말";
-        doReturn("UNSAFE").when(chatModerationService).getAiDecision(input);
+    @DisplayName("AI가 비속어를 발견하면 해당 단어만 ****로 치환된 문장을 반환한다")
+    void shouldReturnFilteredMessage() {
+        String input = "야 이 바보야";
+        String expected = "야 이 ****야";
 
-        String result = chatModerationService.filterMessage(input);
+        doReturn(expected).when(chatModerationService).getAiDecision(input);
 
-        assertThat(result).isEqualTo("⚠️ 클린한 채팅 문화를 만들어주세요!");
-    }
+        String result = chatModerationService.filterMessage(1L, input);
 
-    @Test
-    @DisplayName("AI가 SAFE 판정을 내리면 원문이 그대로 유지된다")
-    void shouldKeepOriginalMessageWhenSafe() {
-        String input = "안녕하세요";
-        doReturn("SAFE").when(chatModerationService).getAiDecision(input);
-
-        String result = chatModerationService.filterMessage(input);
-
-        assertThat(result).isEqualTo("안녕하세요");
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
@@ -46,8 +43,21 @@ class ChatModerationServiceTest {
         String input = "테스트";
         doThrow(new RuntimeException("API 서버 다운")).when(chatModerationService).getAiDecision(input);
 
-        String result = chatModerationService.filterMessage(input);
+        String result = chatModerationService.filterMessage(1L, input);
 
         assertThat(result).isEqualTo("테스트");
+    }
+
+    @Test
+    @DisplayName("1초 이내에 연속으로 채팅을 보내면 도배 에러가 발생한다")
+    void shouldThrowExceptionWhenSpamming() {
+        Long userId = 1L;
+        String input = "안녕하세요";
+
+        chatModerationService.filterMessage(userId, input);
+
+        assertThatThrownBy(() -> chatModerationService.filterMessage(userId, input))
+                .isInstanceOf(backend.drawrace.global.exception.ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "429-1");
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- ai 검열 프롬프트 고도화 및 채팅 도배 방지 로직을 추가하고 4명으로 고정해두었던 인원수를 조정이 가능하도록 수정, chat 도메인 메서드 중복 호출 문제를 해결 했습니다.

## 🔢 작업 단계
- [ ] checkSpam 메서드를 통해 1초 내 연속 채팅 및 중복 메시지를 차단합니다
- [ ] AI 응답을 변수에 할당하여 중복 호출을 제거했습니다
- [ ] maxPlayers를 무조건 4로 저장하던 로직을 req.maxPlayers()를 사용하도록 수정했습니다
- [ ] 기존의 검열 시 원문 전체 치환 대신 부분 ***치환 방식으로 전환 했습니다

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #60 