### PR TITLE
Fix: 방 유저 퇴장 후 자동 삭제 기능 수정

### DIFF
--- a/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import backend.drawrace.domain.room.entity.Participant;

--- a/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/backend/drawrace/domain/room/repository/ParticipantRepository.java
@@ -4,9 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import backend.drawrace.domain.room.entity.Participant;

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -13,9 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.chat.service.AiChatService;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
-import backend.drawrace.domain.round.repository.RoundParticipantRepository;
-import backend.drawrace.domain.round.repository.RoundRepository;
-import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
@@ -24,6 +21,9 @@ import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
 import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.round.repository.RoundParticipantRepository;
+import backend.drawrace.domain.round.repository.RoundRepository;
+import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.user.entity.User;
 import backend.drawrace.domain.user.repository.UserRepository;
 import backend.drawrace.global.exception.ServiceException;
@@ -267,9 +267,8 @@ public class RoomService {
 
         boolean playing = room.isPlaying();
 
-        long activeCount = room.getParticipants().stream()
-                .filter(p -> !p.isLeft())
-                .count();
+        long activeCount =
+                room.getParticipants().stream().filter(p -> !p.isLeft()).count();
 
         if (participant.isHost() && activeCount > 1) {
             Optional<Participant> nextHostOpt = room.getParticipants().stream()

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -82,10 +82,14 @@ public class RoomService {
                             .findFirst()
                             .orElse("Unknown");
 
+                    short activePlayers = (short) room.getParticipants().stream()
+                            .filter(p -> !p.isLeft())
+                            .count();
+
                     return GetRoomListRes.builder()
                             .roomId(room.getId())
                             .title(room.getTitle())
-                            .curPlayers(room.getCurPlayers())
+                            .curPlayers(activePlayers)
                             .maxPlayers(room.getMaxPlayers())
                             .isPlaying(room.isPlaying())
                             .hostNickname(hostNickname)
@@ -263,7 +267,11 @@ public class RoomService {
 
         boolean playing = room.isPlaying();
 
-        if (participant.isHost() && room.getCurPlayers() > 1) {
+        long activeCount = room.getParticipants().stream()
+                .filter(p -> !p.isLeft())
+                .count();
+
+        if (participant.isHost() && activeCount > 1) {
             Optional<Participant> nextHostOpt = room.getParticipants().stream()
                     .filter(p -> !p.equals(participant))
                     .filter(p -> !p.isLeft())

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -13,6 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.chat.service.AiChatService;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
+import backend.drawrace.domain.round.repository.RoundParticipantRepository;
+import backend.drawrace.domain.round.repository.RoundRepository;
+import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
@@ -38,6 +41,9 @@ public class RoomService {
     private final RankingService rankingService;
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectProvider<AiChatService> aiChatServiceProvider;
+    private final RoundSubmissionRepository roundSubmissionRepository;
+    private final RoundParticipantRepository roundParticipantRepository;
+    private final RoundRepository roundRepository;
 
     @Transactional
     public RoomInfoRes createRoom(CreateRoomReq req, Long userId) {
@@ -66,6 +72,8 @@ public class RoomService {
 
     public List<GetRoomListRes> getRoomList() {
         return roomRepository.findAll().stream()
+                .filter(room -> room.getParticipants().stream()
+                        .anyMatch(p -> !p.isLeft() && !p.getUserId().isAi()))
                 .map(room -> {
                     String hostNickname = room.getParticipants().stream()
                             .filter(p -> !p.isLeft())
@@ -264,8 +272,7 @@ public class RoomService {
 
             if (nextHostOpt.isEmpty()) {
                 if (playing) {
-                    // 게임 중에는 round_participant FK 참조 때문에 participant를 삭제하지 않고 퇴장 상태만 변경
-                    room.markParticipantLeft(participant);
+                    deleteRoomWithGameData(room);
                 } else {
                     room.removeParticipant(participant);
                     participantRepository.delete(participant);
@@ -320,7 +327,8 @@ public class RoomService {
         }
 
         if (playing && onlyAiOrEmpty) {
-            room.finishGame();
+            deleteRoomWithGameData(room);
+            return null;
         }
 
         return RoomUpdateResponse.builder()
@@ -337,6 +345,15 @@ public class RoomService {
 
     private List<Participant> getActiveParticipants(Room room) {
         return room.getParticipants().stream().filter(p -> !p.isLeft()).toList();
+    }
+
+    // 게임 중 방 삭제: round_participant FK 순서대로 제거 후 room cascade 삭제
+    private void deleteRoomWithGameData(Room room) {
+        Long roomId = room.getId();
+        roundSubmissionRepository.deleteByRoomId(roomId);
+        roundParticipantRepository.deleteByRoomId(roomId);
+        roundRepository.deleteByRoomId(roomId);
+        roomRepository.delete(room);
     }
 
     @Transactional

--- a/src/main/java/backend/drawrace/domain/round/repository/RoundParticipantRepository.java
+++ b/src/main/java/backend/drawrace/domain/round/repository/RoundParticipantRepository.java
@@ -3,6 +3,7 @@ package backend.drawrace.domain.round.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -33,4 +34,8 @@ public interface RoundParticipantRepository extends JpaRepository<RoundParticipa
           and p.isLeft = false
         """)
     List<RoundParticipant> findActiveByRoundId(@Param("roundId") Long roundId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RoundParticipant rp WHERE rp.round.room.id = :roomId")
+    void deleteByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/backend/drawrace/domain/round/repository/RoundRepository.java
+++ b/src/main/java/backend/drawrace/domain/round/repository/RoundRepository.java
@@ -3,9 +3,16 @@ package backend.drawrace.domain.round.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import backend.drawrace.domain.round.entity.Round;
 
 public interface RoundRepository extends JpaRepository<Round, Long> {
     Optional<Round> findByRoomIdAndIsActiveTrue(Long roomId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Round r WHERE r.room.id = :roomId")
+    void deleteByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/backend/drawrace/domain/round/repository/RoundSubmissionRepository.java
+++ b/src/main/java/backend/drawrace/domain/round/repository/RoundSubmissionRepository.java
@@ -3,6 +3,7 @@ package backend.drawrace.domain.round.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -34,4 +35,8 @@ public interface RoundSubmissionRepository extends JpaRepository<RoundSubmission
         """)
     List<RoundSubmission> findAllWithParticipantAndUserByRoundIdOrderByScoreDescCreatedAtAsc(
             @Param("roundId") Long roundId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RoundSubmission rs WHERE rs.round.room.id = :roomId")
+    void deleteByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/backend/drawrace/global/security/SecurityConfig.java
+++ b/src/main/java/backend/drawrace/global/security/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
                 .authorizeHttpRequests(auth -> auth.requestMatchers(
                                 "/api/auth/signup", "/api/auth/login", "/api/auth/reissue", "/api/auth/guest")
                         .permitAll()
@@ -48,6 +49,8 @@ public class SecurityConfig {
                         .requestMatchers("/ws-draw/**")
                         .permitAll()
                         .requestMatchers("/api/ai/test", "/ai-test.html")
+                        .permitAll()
+                        .requestMatchers("/h2-console/**")
                         .permitAll()
                         .anyRequest()
                         .authenticated())

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -22,12 +22,16 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
+import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
 import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
 import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.round.repository.RoundParticipantRepository;
+import backend.drawrace.domain.round.repository.RoundRepository;
+import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.user.entity.User;
 import backend.drawrace.domain.user.entity.UserStats;
 import backend.drawrace.domain.user.repository.UserRepository;
@@ -50,6 +54,15 @@ class RoomServiceTest {
 
     @Mock
     private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RoundSubmissionRepository roundSubmissionRepository;
+
+    @Mock
+    private RoundParticipantRepository roundParticipantRepository;
+
+    @Mock
+    private RoundRepository roundRepository;
 
     @InjectMocks
     private RoomService roomService;
@@ -172,21 +185,28 @@ class RoomServiceTest {
     }
 
     @Test
-    @DisplayName("게임 중 퇴장하면 참가자를 삭제하지 않고 퇴장 상태로 변경한다")
+    @DisplayName("게임 중 비방장 유저가 퇴장하면 참가자를 삭제하지 않고 퇴장 상태로 변경한다")
     void leaveRoom_DuringGame_MarkParticipantLeftWithoutDelete() throws Exception {
         Long roomId = 10L;
         Long userId = 1L;
+        Long hostId = 2L;
 
-        Room room = createRoom(roomId, "게임방", 2L);
+        Room room = createRoom(roomId, "게임방", hostId);
         setField(room, "isPlaying", true);
         setField(room, "curPlayers", (short) 2);
 
         User user = createUser(userId, "유저A");
+        User hostUser = createUser(hostId, "방장");
+
         Participant participant =
                 Participant.builder().userId(user).room(room).isHost(false).build();
+        Participant hostParticipant =
+                Participant.builder().userId(hostUser).room(room).isHost(true).build();
         setField(participant, "id", 100L);
+        setField(hostParticipant, "id", 101L);
 
         room.getParticipants().add(participant);
+        room.getParticipants().add(hostParticipant);
 
         given(participantRepository.findByRoomIdAndUserId_IdAndIsLeftFalse(roomId, userId))
                 .willReturn(Optional.of(participant));
@@ -203,6 +223,7 @@ class RoomServiceTest {
         assertThat(room.getParticipants()).contains(participant);
 
         verify(participantRepository, never()).delete(any(Participant.class));
+        verify(roomRepository, never()).delete(any(Room.class));
     }
 
     @Test
@@ -414,6 +435,56 @@ class RoomServiceTest {
         RoomUpdateResponse response = roomService.leaveCurrentRoom(userId);
 
         assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("게임 중 호스트 퇴장 후 마지막 유저가 퇴장하면 방이 삭제된다")
+    void leaveRoom_lastUserLeaveDuringGame_roomDeleted() throws Exception {
+        Long roomId = 10L;
+        Long hostId = 1L;
+        Long lastUserId = 2L;
+
+        // 호스트가 이미 퇴장해서 lastUser가 새 호스트인 상황
+        Room room = createRoom(roomId, "게임방", lastUserId);
+        setField(room, "isPlaying", true);
+        setField(room, "curPlayers", (short) 1);
+
+        User lastUser = createUser(lastUserId, "마지막유저");
+        Participant lastParticipant =
+                Participant.builder().userId(lastUser).room(room).isHost(true).build();
+        setField(lastParticipant, "id", 200L);
+
+        room.getParticipants().add(lastParticipant);
+
+        given(participantRepository.findByRoomIdAndUserId_IdAndIsLeftFalse(roomId, lastUserId))
+                .willReturn(Optional.of(lastParticipant));
+
+        RoomUpdateResponse response = roomService.leaveRoom(roomId, lastUserId);
+
+        assertThat(response).isNull();
+        verify(roundSubmissionRepository).deleteByRoomId(roomId);
+        verify(roundParticipantRepository).deleteByRoomId(roomId);
+        verify(roundRepository).deleteByRoomId(roomId);
+        verify(roomRepository).delete(room);
+    }
+
+    @Test
+    @DisplayName("목록 조회 시 활성 인간 참가자가 없는 방은 반환되지 않는다")
+    void getRoomList_excludesRoomsWithNoActiveHumanParticipants() throws Exception {
+        Long roomId = 1L;
+
+        Room ghostRoom = createRoom(roomId, "유령방", 1L);
+        User user = createUser(1L, "유저A");
+        Participant leftParticipant =
+                Participant.builder().userId(user).room(ghostRoom).isHost(false).build();
+        leftParticipant.leave();
+        ghostRoom.getParticipants().add(leftParticipant);
+
+        given(roomRepository.findAll()).willReturn(List.of(ghostRoom));
+
+        List<GetRoomListRes> result = roomService.getRoomList();
+
+        assertThat(result).isEmpty();
     }
 
     private Room createRoom(Long id, String title, Long hostId) throws Exception {

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -469,6 +469,96 @@ class RoomServiceTest {
     }
 
     @Test
+    @DisplayName("게임 전 마지막 유저 퇴장 시 방이 삭제된다")
+    void leaveRoom_lastUserLeaveBeforeGame_roomDeleted() throws Exception {
+        Long roomId = 10L;
+        Long hostId = 1L;
+
+        Room room = createRoom(roomId, "대기방", hostId);
+
+        User hostUser = createUser(hostId, "방장");
+        Participant hostParticipant =
+                Participant.builder().userId(hostUser).room(room).isHost(true).build();
+        setField(hostParticipant, "id", 100L);
+
+        room.getParticipants().add(hostParticipant);
+
+        given(participantRepository.findByRoomIdAndUserId_IdAndIsLeftFalse(roomId, hostId))
+                .willReturn(Optional.of(hostParticipant));
+
+        RoomUpdateResponse response = roomService.leaveRoom(roomId, hostId);
+
+        assertThat(response).isNull();
+        verify(participantRepository).delete(hostParticipant);
+        verify(roomRepository).delete(room);
+    }
+
+    @Test
+    @DisplayName("게임 중 방장 퇴장 시 AI만 남으면 방이 삭제된다")
+    void leaveRoom_hostLeaveDuringGame_onlyAiRemains_roomDeleted() throws Exception {
+        Long roomId = 10L;
+        Long hostId = 1L;
+
+        Room room = createRoom(roomId, "게임방", hostId);
+        setField(room, "isPlaying", true);
+        setField(room, "curPlayers", (short) 2);
+
+        User hostUser = createUser(hostId, "방장");
+        User aiUser = User.builder().nickname("AI").isAi(true).build();
+        setField(aiUser, "id", 99L);
+
+        Participant hostParticipant =
+                Participant.builder().userId(hostUser).room(room).isHost(true).build();
+        Participant aiParticipant =
+                Participant.builder().userId(aiUser).room(room).isHost(false).build();
+        setField(hostParticipant, "id", 100L);
+        setField(aiParticipant, "id", 101L);
+
+        room.getParticipants().add(hostParticipant);
+        room.getParticipants().add(aiParticipant);
+
+        given(participantRepository.findByRoomIdAndUserId_IdAndIsLeftFalse(roomId, hostId))
+                .willReturn(Optional.of(hostParticipant));
+
+        RoomUpdateResponse response = roomService.leaveRoom(roomId, hostId);
+
+        assertThat(response).isNull();
+        verify(roundSubmissionRepository).deleteByRoomId(roomId);
+        verify(roundParticipantRepository).deleteByRoomId(roomId);
+        verify(roundRepository).deleteByRoomId(roomId);
+        verify(roomRepository).delete(room);
+    }
+
+    @Test
+    @DisplayName("목록 조회 시 curPlayers는 실제 활성 인원(isLeft=false) 기준으로 반환된다")
+    void getRoomList_curPlayersReflectsActiveParticipantCount() throws Exception {
+        Long roomId = 1L;
+        Long hostId = 1L;
+
+        Room room = createRoom(roomId, "테스트방", hostId);
+        setField(room, "curPlayers", (short) 2); // 필드값은 2지만 실제 활성 인원은 1
+
+        User hostUser = createUser(hostId, "방장");
+        User leftUser = createUser(2L, "퇴장유저");
+
+        Participant hostParticipant =
+                Participant.builder().userId(hostUser).room(room).isHost(true).build();
+        Participant leftParticipant =
+                Participant.builder().userId(leftUser).room(room).isHost(false).build();
+        leftParticipant.leave(); // isLeft=true
+
+        room.getParticipants().add(hostParticipant);
+        room.getParticipants().add(leftParticipant);
+
+        given(roomRepository.findAll()).willReturn(List.of(room));
+
+        List<GetRoomListRes> result = roomService.getRoomList();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).curPlayers()).isEqualTo((short) 1); // 활성 인원 기준
+    }
+
+    @Test
     @DisplayName("목록 조회 시 활성 인간 참가자가 없는 방은 반환되지 않는다")
     void getRoomList_excludesRoomsWithNoActiveHumanParticipants() throws Exception {
         Long roomId = 1L;


### PR DESCRIPTION
## 📝 작업 내용
- 버그: 게임 중 마지막 유저 퇴장 시 방이 삭제되지 않고 로비에 남는 문제 

## 🔢 작업 단계
- [ ] 게임 중 방 삭제 로직 추가 (deleteRoomWithGameData)
    - FK 순서 문제로 직접 삭제 불가 → round 관련 데이터 순차 삭제 후 방 삭제
- [ ]  getRoomList 개선
    - 활성 인원 없는 방 필터링
    - curPlayers 반환값을 실제 활성 인원(isLeft=false) 기준으로 변경
- [ ] 호스트 위임 조건을 curPlayers 필드 대신 실제 활성 인원 기준으로 변경
- [ ] 테스트 5개 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #