### PR TITLE
[Feat] 라운드 타이머 구현 및 로비 실시간 업데이트

### DIFF
--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -39,6 +39,12 @@ public class RoomService {
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectProvider<AiChatService> aiChatServiceProvider;
 
+    // 최신 방 목록을 로비에 알림
+    public void broadcastLobbyUpdate() {
+        List<GetRoomListRes> roomList = getRoomList(); //
+        messagingTemplate.convertAndSend("/sub/lobby", roomList); //
+    }
+
     @Transactional
     public RoomInfoRes createRoom(CreateRoomReq req, Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
@@ -60,6 +66,8 @@ public class RoomService {
 
         participantRepository.save(host);
         room.getParticipants().add(host);
+
+        broadcastLobbyUpdate();
 
         return getRoomDetail(room.getId());
     }
@@ -161,6 +169,8 @@ public class RoomService {
                         .build();
                 messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", enterNotice);
 
+                broadcastLobbyUpdate();
+
                 return RoomUpdateResponse.builder()
                         .roomId(roomId)
                         .type("USER_ENTER")
@@ -219,6 +229,8 @@ public class RoomService {
         if (aiChatService != null) {
             aiChatService.triggerOnAiJoin(roomId, aiUser.getNickname());
         }
+
+        broadcastLobbyUpdate();
 
         return getRoomDetail(roomId);
     }
@@ -314,14 +326,17 @@ public class RoomService {
         boolean onlyAiOrEmpty = activeParticipants.isEmpty()
                 || activeParticipants.stream().allMatch(p -> p.getUserId().isAi());
 
-        if (!playing && onlyAiOrEmpty) {
+        if (onlyAiOrEmpty) {
             roomRepository.delete(room);
+            broadcastLobbyUpdate();
             return null;
         }
 
         if (playing && onlyAiOrEmpty) {
             room.finishGame();
         }
+
+        broadcastLobbyUpdate();
 
         return RoomUpdateResponse.builder()
                 .roomId(roomId)
@@ -360,6 +375,8 @@ public class RoomService {
 
         room.removeParticipant(aiParticipant);
         participantRepository.delete(aiParticipant);
+
+        broadcastLobbyUpdate();
 
         return getRoomDetail(roomId);
     }

--- a/src/main/java/backend/drawrace/domain/round/dto/RoundStartResponse.java
+++ b/src/main/java/backend/drawrace/domain/round/dto/RoundStartResponse.java
@@ -18,8 +18,9 @@ public class RoundStartResponse {
     private String keyword;
     private RoundStatus status;
     private LocalDateTime startedAt;
+    private int timeLimit;
 
-    public static RoundStartResponse from(Round round) {
+    public static RoundStartResponse from(Round round, int timeLimit) {
         return RoundStartResponse.builder()
                 .roomId(round.getRoom().getId())
                 .roundId(round.getId())
@@ -27,6 +28,7 @@ public class RoundStartResponse {
                 .keyword(round.getKeyword())
                 .status(round.getStatus())
                 .startedAt(round.getStartedAt())
+                .timeLimit(timeLimit)
                 .build();
     }
 }

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -1,19 +1,23 @@
 package backend.drawrace.domain.round.service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.chat.service.AiChatService;
+import backend.drawrace.domain.room.dto.response.GameEvent;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
 import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.room.service.RoomService;
 import backend.drawrace.domain.round.dto.AiInferenceResponse;
 import backend.drawrace.domain.round.dto.CurrentRoundResponse;
 import backend.drawrace.domain.round.dto.PlayerSubmittedEvent;
@@ -52,6 +56,9 @@ public class RoundService {
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
     private final ObjectProvider<AiChatService> aiChatServiceProvider;
+    private final TaskScheduler taskScheduler;
+    private static final int ROUND_TIME_LIMIT = 20;
+    private final RoomService roomService;
 
     /**
      * 게임 시작 처리
@@ -73,7 +80,12 @@ public class RoundService {
         firstRound.start();
         room.startGame();
 
+        roomService.broadcastLobbyUpdate();
+
         Round savedRound = roundRepository.save(firstRound);
+
+        // 타이머 예약
+        scheduleRoundTimeout(savedRound.getId());
 
         // 라운드 참가자 등록은 현재 퇴장하지 않은 참가자만 대상으로 한다.
         List<Participant> participants = participantRepository.findByRoomIdAndIsLeftFalse(roomId);
@@ -81,7 +93,7 @@ public class RoundService {
         triggerAiIfPresent(savedRound, participants);
         triggerAiChatOnRoundStart(roomId, keyword, participants);
 
-        RoundStartResponse response = RoundStartResponse.from(savedRound);
+        RoundStartResponse response = RoundStartResponse.from(savedRound, ROUND_TIME_LIMIT);
 
         ChatMessageDto startNotice = ChatMessageDto.builder()
                 .type(ChatMessageDto.MessageType.NOTICE)
@@ -94,6 +106,32 @@ public class RoundService {
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
 
         return response;
+    }
+
+    // 지정된 시간 뒤에 라운드를 강제로 종료
+    public void scheduleRoundTimeout(Long roundId) {
+        taskScheduler.schedule(
+                () -> {
+                    handleRoundTimeout(roundId);
+                },
+                Instant.now().plusSeconds(ROUND_TIME_LIMIT));
+    }
+
+    @Transactional
+    public void handleRoundTimeout(Long roundId) {
+        Round round = roundRepository.findById(roundId).orElse(null);
+        if (round == null || round.getStatus() != RoundStatus.IN_PROGRESS) return;
+
+        log.info("20초 경과! 해당 방의 모든 클라이언트에 강제 제출 명령을 보냅니다. roundId={}", roundId);
+
+        // 현재까지 그린 걸 제출
+        // 구독 경로: /sub/rooms/{roomId}
+        messagingTemplate.convertAndSend(
+                "/sub/rooms/" + round.getRoom().getId(),
+                GameEvent.builder()
+                        .type("TIME_OVER") // 이벤트 타입 정의[cite: 12]
+                        .data(roundId)
+                        .build());
     }
 
     /**
@@ -288,6 +326,8 @@ public class RoundService {
             roundWinner.markWinner();
             room.finishGame();
 
+            roomService.broadcastLobbyUpdate();
+
             sendFinalWinnerNotice(room.getId(), roundWinner.getUserId().getNickname());
 
             return SubmitDrawingResponse.builder()
@@ -309,6 +349,8 @@ public class RoundService {
         // 아직 일반 라운드가 남아 있으면 다음 라운드 진행
         if (round.getRoundNumber() < room.getTotalRounds()) {
             Round nextRound = createNextRound(room, round.getRoundNumber() + 1);
+
+            scheduleRoundTimeout(nextRound.getId());
 
             // 다음 라운드 참가자 등록도 퇴장하지 않은 참가자만 대상으로 한다.
             List<Participant> participants = participantRepository.findByRoomIdAndIsLeftFalse(room.getId());
@@ -361,6 +403,8 @@ public class RoundService {
             finalWinner.markWinner();
             room.finishGame();
 
+            roomService.broadcastLobbyUpdate();
+
             sendFinalWinnerNotice(room.getId(), finalWinner.getUserId().getNickname());
 
             return SubmitDrawingResponse.builder()
@@ -381,6 +425,7 @@ public class RoundService {
 
         // 동점이면 결승 라운드 생성
         Round tieBreakerRound = createTieBreakerRound(room, round.getRoundNumber() + 1);
+        scheduleRoundTimeout(tieBreakerRound.getId()); // 타이머
         saveRoundParticipants(tieBreakerRound, topScorers);
         triggerAiIfPresent(tieBreakerRound, topScorers);
         triggerAiChatOnRoundStart(room.getId(), tieBreakerRound.getKeyword(), topScorers);

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceLobbyTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceLobbyTest.java
@@ -1,0 +1,68 @@
+package backend.drawrace.domain.room.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import backend.drawrace.domain.room.dto.request.CreateRoomReq;
+import backend.drawrace.domain.room.entity.Room;
+import backend.drawrace.domain.room.repository.ParticipantRepository;
+import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.user.entity.User;
+import backend.drawrace.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RoomServiceLobbyTest {
+
+    @InjectMocks
+    private RoomService roomService;
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    @DisplayName("방 생성 시 로비(/sub/lobby)에 최신 목록이 브로드캐스트 되어야 한다")
+    void createRoomLobbyUpdateTest() {
+        Long userId = 1L;
+        User user = User.builder().nickname("호스트").build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        CreateRoomReq req = new CreateRoomReq("테스트방", (short) 4, (short) 3, null);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(roomRepository.save(any(Room.class))).thenAnswer(i -> {
+            Room r = i.getArgument(0);
+            ReflectionTestUtils.setField(r, "id", 1L); // ID 세팅
+            return r;
+        });
+
+        when(roomRepository.findById(anyLong())).thenAnswer(i -> {
+            Room r = Room.builder().title("테스트방").build();
+            ReflectionTestUtils.setField(r, "id", i.getArgument(0));
+            return Optional.of(r);
+        });
+
+        roomService.createRoom(req, userId);
+
+        verify(messagingTemplate).convertAndSend(eq("/sub/lobby"), anyList());
+    }
+}

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import backend.drawrace.domain.room.service.RoomService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import backend.drawrace.domain.room.entity.Participant;
@@ -76,6 +78,12 @@ class RoundServiceTest {
     @Mock
     private org.springframework.beans.factory.ObjectProvider<backend.drawrace.domain.chat.service.AiChatService>
             aiChatServiceProvider;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private RoomService roomService;
 
     @InjectMocks
     private RoundService roundService;

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTimerTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTimerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -58,6 +59,12 @@ class RoundServiceTimerTest {
     private KeywordGenerator keywordGenerator;
 
     @Mock
+    private RoundParticipantRepository roundParticipantRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
     private RoomService roomService;
 
     @Mock
@@ -65,9 +72,6 @@ class RoundServiceTimerTest {
 
     @Mock
     private AiInferenceService aiInferenceService;
-
-    @Mock
-    private RoundParticipantRepository roundParticipantRepository;
 
     @Mock
     private org.springframework.beans.factory.ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTimerTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTimerTest.java
@@ -1,0 +1,122 @@
+package backend.drawrace.domain.round.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import backend.drawrace.domain.chat.service.AiChatService;
+import backend.drawrace.domain.room.dto.response.GameEvent;
+import backend.drawrace.domain.room.entity.Room;
+import backend.drawrace.domain.room.repository.ParticipantRepository;
+import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.room.service.RoomService;
+import backend.drawrace.domain.round.entity.Round;
+import backend.drawrace.domain.round.entity.RoundStatus;
+import backend.drawrace.domain.round.repository.RoundParticipantRepository;
+import backend.drawrace.domain.round.repository.RoundRepository;
+import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
+import backend.drawrace.domain.round.validator.RoundValidator;
+
+@ExtendWith(MockitoExtension.class)
+class RoundServiceTimerTest {
+
+    @InjectMocks
+    private RoundService roundService;
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @Mock
+    private RoundRepository roundRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RoundValidator roundValidator;
+
+    @Mock
+    private KeywordGenerator keywordGenerator;
+
+    @Mock
+    private RoomService roomService;
+
+    @Mock
+    private RoundSubmissionRepository roundSubmissionRepository;
+
+    @Mock
+    private AiInferenceService aiInferenceService;
+
+    @Mock
+    private RoundParticipantRepository roundParticipantRepository;
+
+    @Mock
+    private org.springframework.beans.factory.ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
+
+    @Mock
+    private org.springframework.beans.factory.ObjectProvider<AiChatService> aiChatServiceProvider;
+
+    @Test
+    @DisplayName("게임 시작 시 20초 스케줄러가 등록되어야 한다")
+    void startGameTimerScheduleTest() {
+        Long roomId = 1L;
+        Room room = Room.builder().build();
+        ReflectionTestUtils.setField(room, "id", roomId);
+        ReflectionTestUtils.setField(room, "hostId", 1L);
+
+        when(roomRepository.findById(roomId)).thenReturn(Optional.of(room));
+        when(participantRepository.findByRoomIdAndIsLeftFalse(roomId)).thenReturn(List.of());
+        when(keywordGenerator.generateKeyword()).thenReturn("사과");
+
+        when(roundRepository.save(any(Round.class))).thenAnswer(i -> {
+            Round r = i.getArgument(0);
+            ReflectionTestUtils.setField(r, "id", 50L);
+            return r;
+        });
+
+        roundService.startGame(roomId, 1L);
+
+        verify(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("타이머 만료 시 TIME_OVER 이벤트가 전송되어야 한다")
+    void handleTimeoutEventTest() {
+        Long roundId = 50L;
+        Room room = Room.builder().build();
+        ReflectionTestUtils.setField(room, "id", 1L);
+
+        Round round = Round.create(room, 1, "사과");
+        ReflectionTestUtils.setField(round, "status", RoundStatus.IN_PROGRESS);
+
+        when(roundRepository.findById(roundId)).thenReturn(Optional.of(round));
+
+        roundService.handleRoundTimeout(roundId);
+
+        verify(messagingTemplate).convertAndSend(eq("/sub/rooms/1"), (Object) argThat(argument -> {
+            if (argument instanceof GameEvent event) {
+                return "TIME_OVER".equals(event.type());
+            }
+            return false;
+        }));
+    }
+}

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.lenient;
 import java.util.List;
 import java.util.Optional;
 
+import backend.drawrace.domain.room.service.RoomService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,7 @@ import backend.drawrace.domain.round.repository.RoundRepository;
 import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
 import backend.drawrace.domain.round.validator.RoundValidator;
 import backend.drawrace.domain.user.entity.User;
+import org.springframework.scheduling.TaskScheduler;
 
 @ExtendWith(MockitoExtension.class)
 class RoundServiceWebSocketTest {
@@ -70,6 +72,12 @@ class RoundServiceWebSocketTest {
 
     @Mock
     private ObjectProvider<backend.drawrace.domain.chat.service.AiChatService> aiChatServiceProvider;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private RoomService roomService;
 
     @Test
     @DisplayName("라운드 종료 시 웹소켓으로 결과가 전송되는지 확인한다")


### PR DESCRIPTION
## 📝 작업 내용
- 모든 라운드 20초 타이머 적용
- 20초 경과 시 강제 제출
- 방의 상태 업데이트 시 로비에 바로 반영

## 🔢 작업 단계
- [ ] RoundStartResponse에 timeLimit 필드 추가하여 프론트엔드 타이머 동기화 지원.
- [ ] startGame, handleAfterRoundFinished, handleLastNormalRound 등 모든 라운드 시작 지점에 20초 스케줄러 예약 로직 적용.
- [ ] 제한 시간 만료 시 /sub/rooms/{roomId}로 TIME_OVER 이벤트 전송.
- [ ] 방의 인원이나 상태가 변경되는 모든 메서드 하단에 broadcastLobbyUpdate() 추가.

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #66 