### PR TITLE
[Feat] redis 고도화

### DIFF
--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.chat.service.AiChatService;
@@ -443,17 +444,39 @@ public class RoomService {
     }
 
     public List<RankingRes> getFinalRanking(Long roomId) {
-        // 해당 방의 모든 참여자 조회
-        List<Participant> participants = participantRepository.findByRoomId(roomId);
+        //  Redis에서 정렬된 랭킹 리스트 가져옴
+        var redisRanking = rankingService.getRankingList(roomId);
 
-        return participants.stream()
+        // Redis에 데이터가 있다면
+        if (redisRanking != null && !redisRanking.isEmpty()) {
+            return redisRanking.stream()
+                    .map(tuple -> {
+                        Long userId = Long.valueOf(tuple.getValue()); // Redis에 저장된 userId
+                        double score = tuple.getScore();             // Redis에 저장된 점수
+
+                        // 참여자 정보 매핑 (닉네임 등을 위해 필요)
+                        return participantRepository.findByRoomIdAndUserId_Id(roomId, userId)
+                                .map(p -> RankingRes.builder()
+                                        .userId(userId)
+                                        .nickname(p.getUserId().getNickname())
+                                        .roundWinCount((int) score)
+                                        .isWinner(p.isWinner())
+                                        .build())
+                                .orElse(null);
+                    })
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+        }
+
+        // Redis가 비어있다면 기존 DB 로직을 Fallback으로 사용
+        return participantRepository.findByRoomId(roomId).stream()
                 .map(p -> RankingRes.builder()
                         .userId(p.getUserId().getId())
                         .nickname(p.getUserId().getNickname())
                         .roundWinCount(p.getRoundWinCount())
                         .isWinner(p.isWinner())
                         .build())
-                .sorted((a, b) -> b.roundWinCount() - a.roundWinCount()) // 승리 횟수 내림차순 정렬
+                .sorted((a, b) -> b.roundWinCount() - a.roundWinCount())
                 .toList();
     }
 

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -9,7 +9,6 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.data.redis.core.ZSetOperations;
 
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.chat.service.AiChatService;
@@ -452,10 +451,11 @@ public class RoomService {
             return redisRanking.stream()
                     .map(tuple -> {
                         Long userId = Long.valueOf(tuple.getValue()); // Redis에 저장된 userId
-                        double score = tuple.getScore();             // Redis에 저장된 점수
+                        double score = tuple.getScore(); // Redis에 저장된 점수
 
                         // 참여자 정보 매핑 (닉네임 등을 위해 필요)
-                        return participantRepository.findByRoomIdAndUserId_Id(roomId, userId)
+                        return participantRepository
+                                .findByRoomIdAndUserId_Id(roomId, userId)
                                 .map(p -> RankingRes.builder()
                                         .userId(userId)
                                         .nickname(p.getUserId().getNickname())

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import backend.drawrace.domain.room.service.RankingService;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -19,6 +18,7 @@ import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
 import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.room.service.RankingService;
 import backend.drawrace.domain.room.service.RoomService;
 import backend.drawrace.domain.round.dto.AiInferenceResponse;
 import backend.drawrace.domain.round.dto.CurrentRoundResponse;
@@ -285,10 +285,8 @@ public class RoundService {
 
         // Redis 실시간 점수 업데이트
         rankingService.updateScore(
-                round.getRoom().getId(),
-                roundWinner.getUserId().getId(),
-                1.0 // 1점씩 증가
-        );
+                round.getRoom().getId(), roundWinner.getUserId().getId(), 1.0 // 1점씩 증가
+                );
 
         round.finish();
 

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import backend.drawrace.domain.room.service.RankingService;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -62,6 +63,7 @@ public class RoundService {
     private final TaskScheduler taskScheduler;
     private static final int ROUND_TIME_LIMIT = 20;
     private final RoomService roomService;
+    private final RankingService rankingService;
 
     /**
      * 게임 시작 처리
@@ -280,6 +282,14 @@ public class RoundService {
 
         Participant roundWinner = winnerSubmission.getParticipant();
         roundWinner.increaseRoundWinCount();
+
+        // Redis 실시간 점수 업데이트
+        rankingService.updateScore(
+                round.getRoom().getId(),
+                roundWinner.getUserId().getId(),
+                1.0 // 1점씩 증가
+        );
+
         round.finish();
 
         Long roomId = round.getRoom().getId();

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import backend.drawrace.domain.room.dto.response.RankingRes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +23,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
+import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
 import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.entity.Participant;
@@ -616,7 +616,8 @@ class RoomServiceTest {
         given(rankingService.getRankingList(roomId)).willReturn(Set.of()); // Redis 비어있음
 
         User user = createUser(1L, "DB유저");
-        Participant participant = Participant.builder().userId(user).roundWinCount(2).build();
+        Participant participant =
+                Participant.builder().userId(user).roundWinCount(2).build();
         given(participantRepository.findByRoomId(roomId)).willReturn(List.of(participant));
 
         // when

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import backend.drawrace.domain.room.dto.response.RankingRes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -575,6 +576,56 @@ class RoomServiceTest {
         List<GetRoomListRes> result = roomService.getRoomList();
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("최종 랭킹 조회 시 Redis에 데이터가 있으면 DB 전체 조회를 생략하고 Redis 데이터를 반환한다")
+    void getFinalRanking_PriorityRedis() throws Exception {
+        // given
+        Long roomId = 100L;
+        Long userId = 1L;
+
+        // Redis 결과 모킹 (TypedTuple)
+        ZSetOperations.TypedTuple<String> tuple = mock(ZSetOperations.TypedTuple.class);
+        given(tuple.getValue()).willReturn(String.valueOf(userId));
+        given(tuple.getScore()).willReturn(3.0);
+        given(rankingService.getRankingList(roomId)).willReturn(Set.of(tuple));
+
+        // DB 개별 조회 모킹
+        User user = createUser(userId, "우승자");
+        Participant participant = Participant.builder().userId(user).build();
+        given(participantRepository.findByRoomIdAndUserId_Id(roomId, userId)).willReturn(Optional.of(participant));
+
+        // when
+        List<RankingRes> result = roomService.getFinalRanking(roomId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).nickname()).isEqualTo("우승자");
+        assertThat(result.get(0).roundWinCount()).isEqualTo(3);
+
+        // 중요: Redis 데이터를 썼으므로 DB 전체 리스트 조회는 발생하지 않아야 함
+        verify(participantRepository, never()).findByRoomId(roomId);
+    }
+
+    @Test
+    @DisplayName("최종 랭킹 조회 시 Redis가 비어있으면 DB에서 데이터를 조회하는 Fallback 로직이 작동한다")
+    void getFinalRanking_FallbackToDb() throws Exception {
+        // given
+        Long roomId = 100L;
+        given(rankingService.getRankingList(roomId)).willReturn(Set.of()); // Redis 비어있음
+
+        User user = createUser(1L, "DB유저");
+        Participant participant = Participant.builder().userId(user).roundWinCount(2).build();
+        given(participantRepository.findByRoomId(roomId)).willReturn(List.of(participant));
+
+        // when
+        List<RankingRes> result = roomService.getFinalRanking(roomId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).nickname()).isEqualTo("DB유저");
+        verify(participantRepository).findByRoomId(roomId); // DB 조회 발생 확인
     }
 
     private Room createRoom(Long id, String title, Long hostId) throws Exception {

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import backend.drawrace.domain.room.service.RankingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +25,7 @@ import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
 import backend.drawrace.domain.room.repository.ParticipantRepository;
 import backend.drawrace.domain.room.repository.RoomRepository;
+import backend.drawrace.domain.room.service.RankingService;
 import backend.drawrace.domain.room.service.RoomService;
 import backend.drawrace.domain.round.dto.AiInferenceResponse;
 import backend.drawrace.domain.round.dto.CurrentRoundResponse;
@@ -311,7 +311,8 @@ class RoundServiceTest {
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
-        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId)).willReturn(true);
+        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
+                .willReturn(true);
         given(aiInferenceService.infer("dummy-image", "사과")).willReturn(new AiInferenceResponse("사과", 0.95));
 
         given(roundSubmissionRepository.countActiveByRoundId(roundId)).willReturn(1L);
@@ -327,7 +328,8 @@ class RoundServiceTest {
         roundService.submitDrawing(roundId, 1L, request);
 
         Long winnerUserId = participant.getUserId().getId();
-        then(rankingService).should().updateScore(eq(roomId), eq(winnerUserId), eq(1.0));    }
+        then(rankingService).should().updateScore(eq(roomId), eq(winnerUserId), eq(1.0));
+    }
 
     @Test
     @DisplayName("라운드 종료 시 현재 제출자 점수와 라운드 승자 점수를 따로 반환한다")

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import backend.drawrace.domain.room.service.RankingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,6 +91,9 @@ class RoundServiceTest {
 
     @Mock
     private RoomService roomService;
+
+    @Mock
+    private RankingService rankingService;
 
     @InjectMocks
     private RoundService roundService;
@@ -288,6 +292,42 @@ class RoundServiceTest {
                 .should()
                 .saveAll(argThat((Iterable<RoundParticipant> iterable) -> countIterable(iterable) == 2));
     }
+
+    @Test
+    @DisplayName("라운드 종료 시 승자의 점수가 Redis에 1점 추가되어야 한다")
+    void submitDrawing_updateRedisRankingOnRoundWinner() throws Exception {
+        Long roomId = 1L;
+        Long roundId = 10L;
+        Long nextRoundId = 11L;
+        Long participantId = 100L;
+
+        Room room = createRoom(roomId, true, 1L);
+        setField(room, "totalRounds", (short) 3);
+        Round round = createInProgressRound(roundId, room, 1, "사과");
+        Participant participant = createParticipant(participantId, room, 0);
+
+        SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
+        RoundSubmission submission = RoundSubmission.create(round, participant, "dummy-image", "사과", 0.95);
+
+        given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
+        given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId)).willReturn(true);
+        given(aiInferenceService.infer("dummy-image", "사과")).willReturn(new AiInferenceResponse("사과", 0.95));
+
+        given(roundSubmissionRepository.countActiveByRoundId(roundId)).willReturn(1L);
+        given(roundParticipantRepository.countActiveByRoundId(roundId)).willReturn(1L);
+        given(roundSubmissionRepository.findByRoundId(roundId)).willReturn(List.of(submission));
+        given(keywordGenerator.generateKeyword()).willReturn("자동차");
+        given(participantRepository.findByRoomIdAndIsLeftFalse(roomId)).willReturn(List.of(participant));
+
+        Round nextRound = Round.create(room, 2, "자동차");
+        setField(nextRound, "id", nextRoundId);
+        given(roundRepository.save(any(Round.class))).willReturn(nextRound);
+
+        roundService.submitDrawing(roundId, 1L, request);
+
+        Long winnerUserId = participant.getUserId().getId();
+        then(rankingService).should().updateScore(eq(roomId), eq(winnerUserId), eq(1.0));    }
 
     @Test
     @DisplayName("라운드 종료 시 현재 제출자 점수와 라운드 승자 점수를 따로 반환한다")


### PR DESCRIPTION
## 📝 작업 내용
- 실시간 점수 반영 및 랭킹 조회 성능을 개선

## 🔢 작업 단계
- [ ] 라운드 승자 판정 시, DB 업데이트와 동시에 RankingService.updateScore()를 호출하여 Redis ZSET에 실시간으로 점수를 기록 합니다.
- [ ] getFinalRanking 메서드 호출 시, Redis 데이터를 최우선적으로 조회하도록 수정했습니다.
- [ ] Redis 데이터가 없는 예외 상황을 대비해 DB에서 데이터를 가져오는 폴백(Fallback) 로직을 유지했습니다.

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #68 