### PR TITLE
Feat: AWS S3 파일 업로드 연동

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dir)"
+    ]
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,8 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
+
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/backend/drawrace/global/config/StorageProperties.java
+++ b/src/main/java/backend/drawrace/global/config/StorageProperties.java
@@ -3,6 +3,7 @@ package backend.drawrace.global.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "storage")
-public record StorageProperties(Local local) {
+public record StorageProperties(Local local, S3 s3) {
     public record Local(String uploadDir, String baseUrl) {}
+    public record S3(String bucket, String region, String baseUrl) {}
 }

--- a/src/main/java/backend/drawrace/global/config/StorageProperties.java
+++ b/src/main/java/backend/drawrace/global/config/StorageProperties.java
@@ -5,5 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "storage")
 public record StorageProperties(Local local, S3 s3) {
     public record Local(String uploadDir, String baseUrl) {}
+
     public record S3(String bucket, String region, String baseUrl) {}
 }

--- a/src/main/java/backend/drawrace/global/storage/S3FileStorageService.java
+++ b/src/main/java/backend/drawrace/global/storage/S3FileStorageService.java
@@ -8,16 +8,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
 import backend.drawrace.global.config.StorageProperties;
 import backend.drawrace.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @Service
@@ -72,10 +71,8 @@ public class S3FileStorageService implements FileStorageService {
         String bucket = storageProperties.s3().bucket();
 
         try {
-            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(filename)
-                    .build();
+            DeleteObjectRequest deleteRequest =
+                    DeleteObjectRequest.builder().bucket(bucket).key(filename).build();
             s3Client.deleteObject(deleteRequest);
         } catch (Exception e) {
             log.warn("S3 파일 삭제 실패: {}", filename, e);

--- a/src/main/java/backend/drawrace/global/storage/S3FileStorageService.java
+++ b/src/main/java/backend/drawrace/global/storage/S3FileStorageService.java
@@ -1,0 +1,91 @@
+package backend.drawrace.global.storage;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import backend.drawrace.global.config.StorageProperties;
+import backend.drawrace.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(name = "storage.mode", havingValue = "s3")
+@RequiredArgsConstructor
+public class S3FileStorageService implements FileStorageService {
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp");
+
+    private final StorageProperties storageProperties;
+    private final S3Client s3Client;
+
+    @Override
+    public String store(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new ServiceException("400-2", "파일이 비어 있습니다.");
+        }
+
+        String ext = extractExtension(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(ext.toLowerCase())) {
+            throw new ServiceException("400-2", "허용되지 않는 파일 형식입니다. (jpg, jpeg, png, gif, webp)");
+        }
+
+        String filename = UUID.randomUUID() + "." + ext;
+        String bucket = storageProperties.s3().bucket();
+
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(filename)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(putRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패: {}", filename, e);
+            throw new ServiceException("500-2", "파일 저장에 실패했습니다.");
+        }
+
+        return storageProperties.s3().baseUrl() + "/" + filename;
+    }
+
+    @Override
+    public void delete(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) return;
+
+        String baseUrl = storageProperties.s3().baseUrl();
+        if (!fileUrl.startsWith(baseUrl)) return;
+
+        String filename = fileUrl.substring(baseUrl.length() + 1);
+        String bucket = storageProperties.s3().bucket();
+
+        try {
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(filename)
+                    .build();
+            s3Client.deleteObject(deleteRequest);
+        } catch (Exception e) {
+            log.warn("S3 파일 삭제 실패: {}", filename, e);
+        }
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            throw new ServiceException("400-2", "파일 확장자를 확인할 수 없습니다.");
+        }
+        return filename.substring(filename.lastIndexOf('.') + 1);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -43,10 +43,14 @@ ai:
     model: ${AI_MODEL:}
 
 storage:
-  mode: local
+  mode: ${STORAGE_MODE:s3}
   local:
     upload-dir: ${STORAGE_LOCAL_UPLOAD_DIR:/home/ubuntu/uploads}
     base-url: ${STORAGE_LOCAL_BASE_URL:http://localhost:8080/files/uploads}
+  s3:
+    bucket: ${STORAGE_S3_BUCKET}
+    region: ${STORAGE_S3_REGION:ap-northeast-2}
+    base-url: ${STORAGE_S3_BASE_URL}
 
 logging:
   level:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,6 +22,16 @@ spring:
       host: localhost
       port: 6379
 
+spring:
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+        auto: false
+      credentials:
+        access-key: test
+        secret-key: test
+
 jwt:
   secret: test-secret-key-for-testing-purpose-only-32bytes
   access-expiration: 3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,16 @@ ai:
     api-key: ${AI_GATEWAY_API_KEY:}
     model: ${AI_MODEL:}
 
+spring:
+  cloud:
+    aws:
+      region:
+        static: ${AWS_REGION:ap-northeast-2}
+        auto: false
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID:test}
+        secret-key: ${AWS_SECRET_ACCESS_KEY:test}
+
 storage:
   mode: local
   local:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,14 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+  cloud:
+    aws:
+      region:
+        static: ${AWS_REGION:ap-northeast-2}
+        auto: false
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID:test}
+        secret-key: ${AWS_SECRET_ACCESS_KEY:test}
 
 jwt:
   secret: ${JWT_SECRET_KEY:your_default_secret_key_at_least_32_bytes_long}
@@ -41,16 +49,6 @@ ai:
     base-url: ${AI_GATEWAY_BASE_URL:}
     api-key: ${AI_GATEWAY_API_KEY:}
     model: ${AI_MODEL:}
-
-spring:
-  cloud:
-    aws:
-      region:
-        static: ${AWS_REGION:ap-northeast-2}
-        auto: false
-      credentials:
-        access-key: ${AWS_ACCESS_KEY_ID:test}
-        secret-key: ${AWS_SECRET_ACCESS_KEY:test}
 
 storage:
   mode: local


### PR DESCRIPTION
## 📝 작업 내용
운영환경에서 사용자의 프로필 사진이나 퀵드로우 데이터셋을 저장하기 위해 S3 스토리지를 도입한다.

## 🔢 작업 단계
- [ ] S3 의존성 추가
- [ ] StorageProperties record에 S3(bucket, region, baseUrl) 추가
- [ ] S3FileStorageService 구현체 작성
- [ ] application-prod.yml에 storage 섹션에 s3 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #73 