### PR TITLE
[Feat] 채팅 검열 로직 성능 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,11 +70,10 @@ dependencies {
 
 
     // PyTorch
-    implementation(platform("ai.djl:bom:0.26.0"))
-    implementation("ai.djl:api")
-    implementation("ai.djl.pytorch:pytorch-engine")
-    runtimeOnly("ai.djl.pytorch:pytorch-native-auto")
-    implementation("ai.djl.huggingface:tokenizers")
+    implementation("ai.djl:api:0.26.0")
+    implementation("ai.djl.pytorch:pytorch-engine:0.26.0")
+    runtimeOnly("ai.djl.pytorch:pytorch-native-auto:2.1.1")
+    implementation("ai.djl.huggingface:tokenizers:0.26.0")
 
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,13 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
 
+
+    // PyTorch
+    implementation("ai.djl:api:0.25.0")
+    implementation("ai.djl.pytorch:pytorch-engine:0.25.0")
+    runtimeOnly("ai.djl.pytorch:pytorch-native-auto:2.1.0")
+    implementation("ai.djl.huggingface:tokenizers:0.25.0")
+
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     // PyTorch
     implementation("ai.djl:api:0.25.0")
     implementation("ai.djl.pytorch:pytorch-engine:0.25.0")
-    runtimeOnly("ai.djl.pytorch:pytorch-native-auto:2.1.0")
+    runtimeOnly("ai.djl.pytorch:pytorch-native-auto:0.25.0")
     implementation("ai.djl.huggingface:tokenizers:0.25.0")
 
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,10 @@ dependencies {
 
 
     // PyTorch
-    implementation("ai.djl:api:0.25.0")
-    implementation("ai.djl.pytorch:pytorch-engine:0.25.0")
-    runtimeOnly("ai.djl.pytorch:pytorch-native-cpu:0.25.0")
-    implementation("ai.djl.huggingface:tokenizers:0.25.0")
+    implementation("ai.djl:api:0.26.0")
+    implementation("ai.djl.pytorch:pytorch-engine:0.26.0")
+    runtimeOnly("ai.djl.pytorch:pytorch-native-cpu:0.26.0")
+    implementation("ai.djl.huggingface:tokenizers:0.26.0")
 
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,6 @@ dependencies {
     // PyTorch
     implementation("ai.djl:api:0.26.0")
     implementation("ai.djl.pytorch:pytorch-engine:0.26.0")
-    runtimeOnly("ai.djl.pytorch:pytorch-native-auto:2.1.1")
     implementation("ai.djl.huggingface:tokenizers:0.26.0")
 
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,11 @@ dependencies {
 
 
     // PyTorch
-    implementation("ai.djl:api:0.26.0")
-    implementation("ai.djl.pytorch:pytorch-engine:0.26.0")
-    runtimeOnly("ai.djl.pytorch:pytorch-native-cpu:0.26.0")
-    implementation("ai.djl.huggingface:tokenizers:0.26.0")
+    implementation(platform("ai.djl:bom:0.26.0"))
+    implementation("ai.djl:api")
+    implementation("ai.djl.pytorch:pytorch-engine")
+    runtimeOnly("ai.djl.pytorch:pytorch-native-auto")
+    implementation("ai.djl.huggingface:tokenizers")
 
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     // PyTorch
     implementation("ai.djl:api:0.25.0")
     implementation("ai.djl.pytorch:pytorch-engine:0.25.0")
-    runtimeOnly("ai.djl.pytorch:pytorch-native-auto:0.25.0")
+    runtimeOnly("ai.djl.pytorch:pytorch-native-cpu:0.25.0")
     implementation("ai.djl.huggingface:tokenizers:0.25.0")
 
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")

--- a/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
+++ b/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
@@ -14,7 +14,9 @@ import backend.drawrace.global.exception.ServiceException;
 import backend.drawrace.global.security.SecurityUser;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class ChatController {
@@ -32,6 +34,9 @@ public class ChatController {
             return; // 아무것도 하지 않고 종료
         }
 
+        org.springframework.util.StopWatch stopWatch = new org.springframework.util.StopWatch();
+        stopWatch.start();
+
         SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
 
         User user = userRepository
@@ -39,13 +44,17 @@ public class ChatController {
                 .orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
 
         // AI 검열 실행
-        String filteredMessage =
-                chatModerationService.filterMessage(securityUser.getUserId(), chatMessage.getMessage());
+        String filteredMessage = chatModerationService.fastFilter(securityUser.getUserId(), chatMessage.getMessage());
+
+        stopWatch.stop();
+        log.info("[성능체크] 채팅 필터링 완료 - 소요시간: {}ms, 메시지: {}", stopWatch.getTotalTimeMillis(), filteredMessage);
 
         chatMessage.setSender(user.getNickname());
         chatMessage.setMessage(filteredMessage);
         // 일반 채팅은 TALK 타입으로 고정하여 브로드캐스팅
         chatMessage.setType(ChatMessageDto.MessageType.TALK);
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);
+
+        chatModerationService.processAiModeration(roomId, chatMessage);
     }
 }

--- a/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
@@ -1,12 +1,18 @@
 package backend.drawrace.domain.chat.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
 import backend.drawrace.domain.round.dto.gateway.GatewayChatRequest;
 import backend.drawrace.domain.round.dto.gateway.GatewayChatResponse;
 import backend.drawrace.global.config.AiProperties;
@@ -21,7 +27,127 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatModerationService {
 
     private final AiProperties aiProperties;
+    private final RestClient restClient;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final EmbeddingService embeddingService;
 
+    private final Map<Long, LastChatInfo> chatHistory = new ConcurrentHashMap<>();
+    private final List<float[]> aggressiveVectors = new ArrayList<>();
+
+    private static final int SPAM_LIMIT_MS = 1000;
+    private static final String BANNED_PATTERN = ".*(시발|병신|개새끼|패드립|느금).*";
+    private static final double SIMILARITY_THRESHOLD = 0.82;
+
+    @PostConstruct
+    public void initAggressiveVectors() {
+        List<String> samples = List.of(
+                "너 진짜 지능 낮냐",
+                "그림 진짜 못 그린다",
+                "손가락 장애 있음?",
+                "나가 죽어라",
+                "뇌가 없나보네",
+                "진짜 극혐이다",
+                "손가락 문제 있냐",
+                "가정교육 독학했냐",
+                "부모님 안 계시냐",
+                "부모님 홀수냐");
+        for (String sample : samples) {
+            aggressiveVectors.add(embeddingService.embed(sample));
+        }
+        log.info("공격적 문장 임베딩 데이터 {}건 로드 완료!", aggressiveVectors.size());
+    }
+
+    public String fastFilter(Long userId, String originalMessage) {
+        // 도배 체크
+        checkSpam(userId, originalMessage);
+
+        String normalized = originalMessage.replaceAll("[^가-힣]", "");
+
+        String BANNED_PATTERN = ".*(시발|ㅅㅂ|씨발|병신|ㅂㅅ|새끼|야발|지랄|니미|느금|ㅗ).*";
+
+        // 키워드 기반 즉시 차단
+        if (originalMessage.matches(BANNED_PATTERN)) {
+            return "****"; // 욕설 발견 시 즉시 마스킹
+        }
+
+        // 임베딩 유사도 체크
+        float[] currentVector = embeddingService.embed(originalMessage);
+
+        // 미리 저장해둔 나쁜 문장들과 하나씩 비교
+        for (float[] badVector : aggressiveVectors) {
+            double similarity = embeddingService.calculateSimilarity(currentVector, badVector);
+            if (similarity > SIMILARITY_THRESHOLD) {
+                log.info("임베딩 검열 감지 (유사도: {}): {}", similarity, originalMessage);
+                return "[부적절한 메시지입니다]";
+            }
+        }
+
+        return originalMessage; // 깨끗하면 원문 그대로 즉시 반환
+    }
+
+    @Async("taskExecutor")
+    public void processAiModeration(Long roomId, ChatMessageDto chatMessage) {
+        try {
+
+            String aiResult = getAiDecisionStrict(chatMessage.getMessage());
+
+            if ("1".equals(aiResult)) {
+                // 부적절하다고 판단되면 메시지를 교체하고 다시 브로드캐스트
+                chatMessage.setMessage("[AI 검열에 의해 삭제된 메시지입니다]");
+                messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);
+                log.info("AI가 부적절한 메시지 감지 및 수정 완료: {}", chatMessage.getMessage());
+            }
+        } catch (Exception e) {
+            log.error("비동기 AI 검열 중 오류 발생: {}", e.getMessage());
+        }
+    }
+
+    private String getAiDecisionStrict(String message) {
+        String systemPrompt = """
+                너는 온라인 게임의 채팅 검열관이야.
+                사용자의 메시지가 욕설, 비하, 따돌림, 혹은 심각한 공격성을 띄는지 판단해.
+                [규칙]
+                - 부적절하면 오직 '1'만 출력.
+                - 적절하면 오직 '0'만 출력.
+                - 다른 설명은 절대 금지.
+                """;
+
+        try {
+            GatewayChatRequest request = GatewayChatRequest.builder()
+                    .model(aiProperties.model())
+                    .messages(List.of(
+                            GatewayChatRequest.systemMessage(systemPrompt), GatewayChatRequest.userMessage(message)))
+                    .temperature(0.0)
+                    .build();
+
+            GatewayChatResponse response = restClient
+                    .post()
+                    .uri("/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .toEntity(GatewayChatResponse.class)
+                    .getBody();
+
+            return response.getChoices().get(0).getMessage().getContent().trim();
+        } catch (Exception e) {
+            return "0";
+        }
+    }
+
+    private void checkSpam(Long userId, String message) {
+        long now = System.currentTimeMillis();
+        LastChatInfo last = chatHistory.get(userId);
+
+        if (last != null) {
+            if (now - last.timestamp < SPAM_LIMIT_MS) throw new ServiceException("429-1", "채팅이 너무 빠릅니다.");
+            if (last.message.equals(message)) throw new ServiceException("429-2", "동일한 내용의 채팅입니다.");
+        }
+        chatHistory.put(userId, new LastChatInfo(message, now));
+    }
+
+    private record LastChatInfo(String message, long timestamp) {}
+
+    /*
     private final Map<Long, LastChatInfo> chatHistory = new ConcurrentHashMap<>();
     private static final int SPAM_LIMIT_MS = 1000;
 
@@ -114,4 +240,6 @@ public class ChatModerationService {
     }
 
     private record LastChatInfo(String message, long timestamp) {}
+
+     */
 }

--- a/src/main/java/backend/drawrace/domain/chat/service/EmbeddingService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/EmbeddingService.java
@@ -1,0 +1,54 @@
+package backend.drawrace.domain.chat.service;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.stereotype.Service;
+
+import ai.djl.inference.Predictor;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ZooModel;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class EmbeddingService {
+    private Predictor<String, float[]> predictor;
+
+    @PostConstruct
+    public void init() throws Exception {
+
+        Criteria<String, float[]> criteria = Criteria.builder()
+                .setTypes(String.class, float[].class)
+                .optModelUrls(
+                        "djl://ai.djl.huggingface.pytorch/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
+                .optEngine("OnnxRuntime")
+                .optEngine("PyTorch")
+                .build();
+
+        ZooModel<String, float[]> model = criteria.loadModel();
+        this.predictor = model.newPredictor();
+        log.info("임베딩 AI 모델 로드 완료!");
+    }
+
+    public float[] embed(String text) {
+        try {
+            return predictor.predict(text);
+        } catch (Exception e) {
+            log.error("임베딩 생성 실패: {}", e.getMessage());
+            return new float[0];
+        }
+    }
+
+    // 두 문장의 유사도 계산 (코사인 유사도)
+    public double calculateSimilarity(float[] vectorA, float[] vectorB) {
+        double dotProduct = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+        for (int i = 0; i < vectorA.length; i++) {
+            dotProduct += vectorA[i] * vectorB[i];
+            normA += Math.pow(vectorA[i], 2);
+            normB += Math.pow(vectorB[i], 2);
+        }
+        return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+}

--- a/src/main/java/backend/drawrace/global/config/AsyncConfig.java
+++ b/src/main/java/backend/drawrace/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package backend.drawrace.global.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5); // 평소에 5개의 스레드 유지
+        executor.setMaxPoolSize(10); // 채팅이 몰리면 최대 10개까지 확장
+        executor.setQueueCapacity(500); // 10개가 다 차면 500개까지 줄 세움
+        executor.setThreadNamePrefix("ChatAsync-"); // 로그 찍힐 때 이름 (디버깅용)
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/backend/drawrace/global/config/RestClientConfig.java
+++ b/src/main/java/backend/drawrace/global/config/RestClientConfig.java
@@ -1,0 +1,17 @@
+package backend.drawrace.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient(AiProperties aiProperties) {
+        return RestClient.builder()
+                .baseUrl(aiProperties.baseUrl())
+                .defaultHeader("Authorization", "Bearer " + aiProperties.apiKey()) // API 키 설정
+                .build();
+    }
+}

--- a/src/test/java/backend/drawrace/domain/chat/ChatPerformanceTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/ChatPerformanceTest.java
@@ -1,0 +1,40 @@
+package backend.drawrace.domain.chat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import backend.drawrace.domain.chat.controller.ChatController;
+import backend.drawrace.domain.chat.dto.ChatMessageDto;
+import backend.drawrace.global.security.SecurityUser;
+
+@SpringBootTest
+class ChatPerformanceTest {
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ChatPerformanceTest.class);
+
+    @Autowired
+    private ChatController chatController;
+
+    @Test
+    @DisplayName("실제 로직을 돌려서 콘솔에 찍히는 시간을 확인한다")
+    void checkChatSpeed() {
+        // 1. 가짜 데이터 준비 (채은이가 테스트하고 싶은 문장)
+        Long roomId = 1L;
+        ChatMessageDto message = ChatMessageDto.builder()
+                .message("그림 진짜 못 그리네") // 유사도 검사가 일어날 문장
+                .build();
+
+        // 2. Authentication 객체 만들기 (Security 환경이라면 필요해)
+        SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
+        Authentication auth = new UsernamePasswordAuthenticationToken(securityUser, null, null);
+
+        // 3. 컨트롤러 메서드 직접 호출!
+        log.info("=== 테스트 시작 ===");
+        chatController.sendChatMessage(roomId, message, auth);
+        log.info("=== 테스트 종료 ===");
+    }
+}

--- a/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
@@ -56,7 +56,7 @@ class ChatControllerTest {
         User user = User.builder().nickname(realNickname).build();
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        when(chatModerationService.filterMessage(anyLong(), anyString()))
+        when(chatModerationService.fastFilter(anyLong(), anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(1));
 
         chatController.sendChatMessage(roomId, requestDto, auth);
@@ -99,17 +99,37 @@ class ChatControllerTest {
 
         User user = User.builder().nickname("유저A").build();
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
-        when(chatModerationService.filterMessage(anyLong(), eq(raw))).thenReturn(filtered); // 가짜 응답
+        when(chatModerationService.fastFilter(anyLong(), eq(raw))).thenReturn(filtered); // 가짜 응답
 
         SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
         Authentication auth = new UsernamePasswordAuthenticationToken(securityUser, null, null);
 
-        // When
         chatController.sendChatMessage(roomId, requestDto, auth);
 
-        // Then: 최종적으로 나가는 메시지가 '필터링된 문구'인지 확인!
         verify(messagingTemplate)
                 .convertAndSend(eq("/sub/rooms/" + roomId + "/chat"), argThat((ChatMessageDto dto) -> dto.getMessage()
                         .equals(filtered)));
+    }
+
+    @Test
+    @DisplayName("채팅 전송 시 로컬 필터를 거쳐 즉시 전송되고 AI 검사가 비동기로 호출된다")
+    void shouldSendFastAndCallAsyncAi() {
+        Long roomId = 1L;
+        ChatMessageDto requestDto = ChatMessageDto.builder().message("안녕").build();
+
+        SecurityUser securityUser = new SecurityUser(1L, "test@test.com");
+        Authentication auth =
+                new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities());
+
+        User user = User.builder().nickname("유저").build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        when(chatModerationService.fastFilter(anyLong(), anyString())).thenReturn("안녕");
+
+        chatController.sendChatMessage(roomId, requestDto, auth);
+
+        verify(messagingTemplate).convertAndSend(eq("/sub/rooms/" + roomId + "/chat"), any(ChatMessageDto.class));
+
+        verify(chatModerationService).processAiModeration(eq(roomId), any(ChatMessageDto.class));
     }
 }

--- a/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import backend.drawrace.global.config.AiProperties;
 
@@ -19,33 +20,68 @@ class ChatModerationServiceTest {
     @Mock
     private AiProperties aiProperties;
 
+    @Mock
+    private EmbeddingService embeddingService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
     @Spy
     @InjectMocks
     private ChatModerationService chatModerationService;
 
+    /*
+       @Test
+       @DisplayName("AI가 비속어를 발견하면 해당 단어만 ****로 치환된 문장을 반환한다")
+       void shouldReturnFilteredMessage() {
+           String input = "야 이 바보야";
+           String expected = "야 이 ****야";
+
+           doReturn(expected).when(chatModerationService).getAiDecision(input);
+
+           String result = chatModerationService.filterMessage(1L, input);
+
+           assertThat(result).isEqualTo(expected);
+       }
+
+       @Test
+       @DisplayName("AI 서버 에러 발생 시 원문이 그대로 반환된다")
+       void shouldReturnOriginalOnFailure() {
+           // AI 서버 통신 중 예외 발생 시나리오
+           String input = "테스트";
+           doThrow(new RuntimeException("API 서버 다운")).when(chatModerationService).getAiDecision(input);
+
+           String result = chatModerationService.filterMessage(1L, input);
+
+           assertThat(result).isEqualTo("테스트");
+       }
+
+    */
+
     @Test
-    @DisplayName("AI가 비속어를 발견하면 해당 단어만 ****로 치환된 문장을 반환한다")
-    void shouldReturnFilteredMessage() {
-        String input = "야 이 바보야";
-        String expected = "야 이 ****야";
+    @DisplayName("임베딩 유사도가 높으면 부적절한 메시지로 판정한다")
+    void shouldFilterByEmbedding() {
 
-        doReturn(expected).when(chatModerationService).getAiDecision(input);
+        String input = "나쁜 문장";
+        float[] mockVector = new float[] {0.1f, 0.2f};
 
-        String result = chatModerationService.filterMessage(1L, input);
+        when(embeddingService.embed(anyString())).thenReturn(mockVector);
 
-        assertThat(result).isEqualTo(expected);
+        chatModerationService.initAggressiveVectors();
+
+        when(embeddingService.calculateSimilarity(any(), any())).thenReturn(0.9);
+
+        String result = chatModerationService.fastFilter(1L, input);
+
+        assertThat(result).isEqualTo("[부적절한 메시지입니다]");
     }
 
     @Test
-    @DisplayName("AI 서버 에러 발생 시 원문이 그대로 반환된다")
-    void shouldReturnOriginalOnFailure() {
-        // AI 서버 통신 중 예외 발생 시나리오
-        String input = "테스트";
-        doThrow(new RuntimeException("API 서버 다운")).when(chatModerationService).getAiDecision(input);
-
-        String result = chatModerationService.filterMessage(1L, input);
-
-        assertThat(result).isEqualTo("테스트");
+    @DisplayName("비속어 패턴에 걸리면 즉시 ****로 치환한다")
+    void shouldFilterByPattern() {
+        String input = "야 이 시발";
+        String result = chatModerationService.fastFilter(1L, input);
+        assertThat(result).contains("****");
     }
 
     @Test
@@ -54,10 +90,11 @@ class ChatModerationServiceTest {
         Long userId = 1L;
         String input = "안녕하세요";
 
-        doReturn(input).when(chatModerationService).getAiDecision(input);
-        chatModerationService.filterMessage(userId, input);
+        when(embeddingService.embed(anyString())).thenReturn(new float[] {0.0f});
+        // doReturn(input).when(chatModerationService).getAiDecision(input);
+        chatModerationService.fastFilter(userId, input);
 
-        assertThatThrownBy(() -> chatModerationService.filterMessage(userId, input))
+        assertThatThrownBy(() -> chatModerationService.fastFilter(userId, input))
                 .isInstanceOf(backend.drawrace.global.exception.ServiceException.class)
                 .hasFieldOrPropertyWithValue("resultCode", "429-1");
     }

--- a/src/test/java/backend/drawrace/domain/chat/service/EmbeddingRealScoreTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/service/EmbeddingRealScoreTest.java
@@ -1,0 +1,28 @@
+package backend.drawrace.domain.chat.service;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EmbeddingRealScoreTest {
+
+    @Autowired
+    private EmbeddingService embeddingService;
+
+    @Test
+    void measureRealSimilarity() {
+        float[] target = embeddingService.embed("그림 진짜 못 그린다");
+
+        List<String> tests = List.of("그림 실력 실화냐", "진짜 못 그리네", "손가락 문제 있음?");
+
+        System.out.println("\n=== 실제 AI 유사도 측정 결과 ===");
+        for (String text : tests) {
+            float[] testVec = embeddingService.embed(text);
+            double score = embeddingService.calculateSimilarity(target, testVec);
+            System.out.printf("문장: [%s] -> 유사도: %.4f%n", text, score);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- - AI 채팅 검열 시 발생하는 약 6초의 응답 지연 문제를 해결하기 위해 **3단계  필터링 시스템**을 도입했습니다.
- **1단계(정규식):** 변칙 욕설 즉시 차단
- **2단계(임베딩):** 로컬 모델을 이용한 문맥적 비하/비꼬기 감지
- **3단계(비동기 AI):** 정밀 검사 결과를 사후에 업데이트하는 방식 적용

## 🔢 작업 단계
- [ ] AsyncConfig 및 RestClientConfig 설정
- [ ] EmbeddingService 구현
- [ ] ChatModerationService 로직 개편
- [ ] ChatController 성능 측정 로그 및 필터링 연동

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #77 