### PR TITLE
feat: CORS 설정 추가 (Vercel + localhost)

### DIFF
--- a/src/main/java/backend/drawrace/global/security/SecurityConfig.java
+++ b/src/main/java/backend/drawrace/global/security/SecurityConfig.java
@@ -2,9 +2,6 @@ package backend.drawrace.global.security;
 
 import java.util.List;
 
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,6 +12,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -73,12 +73,11 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(List.of(
                 "https://int-1-project-team05-fe.vercel.app",
                 "https://int-1-project-team05-fe-*.vercel.app",
-                "http://localhost:3000"
-        ));
+                "http://localhost:3000"));
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("Authorization"));  // JWT 토큰 노출
+        config.setExposedHeaders(List.of("Authorization")); // JWT 토큰 노출
         config.setAllowCredentials(true);
         config.setMaxAge(3600L);
 

--- a/src/main/java/backend/drawrace/global/security/SecurityConfig.java
+++ b/src/main/java/backend/drawrace/global/security/SecurityConfig.java
@@ -1,5 +1,10 @@
 package backend.drawrace.global.security;
 
+import java.util.List;
+
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,6 +41,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
                 .authorizeHttpRequests(auth -> auth.requestMatchers(
@@ -57,5 +63,27 @@ public class SecurityConfig {
                 .addFilterBefore(customAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 허용할 도메인 (production + preview + 로컬)
+        config.setAllowedOriginPatterns(List.of(
+                "https://int-1-project-team05-fe.vercel.app",
+                "https://int-1-project-team05-fe-*.vercel.app",
+                "http://localhost:3000"
+        ));
+
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));  // JWT 토큰 노출
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- SecurityConfig에 CORS 설정 추가
- 프론트(Vercel)에서 백엔드(EC2) API 호출 가능하도록 허용 도메인 명시

## 🔢 작업 단계
- [x] `CorsConfigurationSource` 빈 메서드 추가
- [x] SecurityFilterChain에 `.cors()` 활성화
- [x] 허용 도메인 등록 (Vercel production / preview / localhost)

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #