### PR TITLE
Feature: 친구 초대 기능 추가

### DIFF
--- a/src/main/java/backend/drawrace/domain/room/controller/RoomController.java
+++ b/src/main/java/backend/drawrace/domain/room/controller/RoomController.java
@@ -106,6 +106,16 @@ public class RoomController {
         return new RsData<>("200-1", "랭킹 조회 성공", ranking);
     }
 
+    @Operation(summary = "친구 초대")
+    @PostMapping("/{roomId}/invite/{friendId}")
+    public RsData<Void> inviteFriend(
+            @PathVariable Long roomId,
+            @PathVariable Long friendId,
+            @AuthenticationPrincipal SecurityUser securityUser) {
+        roomService.inviteFriend(roomId, securityUser.getUserId(), friendId);
+        return new RsData<>("200-8", "초대를 전송했습니다.");
+    }
+
     @Operation(summary = "AI 참가자 추가")
     @PostMapping("/{roomId}/ai-participants")
     public RsData<RoomInfoRes> addAiParticipant(

--- a/src/main/java/backend/drawrace/domain/room/dto/response/RoomInviteResponse.java
+++ b/src/main/java/backend/drawrace/domain/room/dto/response/RoomInviteResponse.java
@@ -1,0 +1,8 @@
+package backend.drawrace.domain.room.dto.response;
+
+public record RoomInviteResponse(
+        Long roomId,
+        String roomTitle,
+        Long hostId,
+        String hostNickname
+) {}

--- a/src/main/java/backend/drawrace/domain/room/dto/response/RoomInviteResponse.java
+++ b/src/main/java/backend/drawrace/domain/room/dto/response/RoomInviteResponse.java
@@ -1,8 +1,3 @@
 package backend.drawrace.domain.room.dto.response;
 
-public record RoomInviteResponse(
-        Long roomId,
-        String roomTitle,
-        Long hostId,
-        String hostNickname
-) {}
+public record RoomInviteResponse(Long roomId, String roomTitle, Long hostId, String hostNickname) {}

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -16,6 +16,7 @@ import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
+import backend.drawrace.domain.room.dto.response.RoomInviteResponse;
 import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
@@ -24,7 +25,6 @@ import backend.drawrace.domain.room.repository.RoomRepository;
 import backend.drawrace.domain.round.repository.RoundParticipantRepository;
 import backend.drawrace.domain.round.repository.RoundRepository;
 import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
-import backend.drawrace.domain.room.dto.response.RoomInviteResponse;
 import backend.drawrace.domain.user.entity.Friendship;
 import backend.drawrace.domain.user.entity.FriendshipStatus;
 import backend.drawrace.domain.user.entity.User;
@@ -543,10 +543,13 @@ public class RoomService {
             throw new ServiceException("400-3", "방 인원이 초과되었습니다.");
         }
 
-        User inviter = userRepository.findById(inviterId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
-        User friend = userRepository.findById(friendId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
+        User inviter =
+                userRepository.findById(inviterId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
+        User friend =
+                userRepository.findById(friendId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
 
-        Friendship friendship = friendshipRepository.findByUsers(inviter, friend)
+        Friendship friendship = friendshipRepository
+                .findByUsers(inviter, friend)
                 .orElseThrow(() -> new ServiceException("403-3", "친구 관계가 아닙니다."));
 
         if (friendship.getStatus() != FriendshipStatus.ACCEPTED) {

--- a/src/main/java/backend/drawrace/domain/room/service/RoomService.java
+++ b/src/main/java/backend/drawrace/domain/room/service/RoomService.java
@@ -24,7 +24,11 @@ import backend.drawrace.domain.room.repository.RoomRepository;
 import backend.drawrace.domain.round.repository.RoundParticipantRepository;
 import backend.drawrace.domain.round.repository.RoundRepository;
 import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
+import backend.drawrace.domain.room.dto.response.RoomInviteResponse;
+import backend.drawrace.domain.user.entity.Friendship;
+import backend.drawrace.domain.user.entity.FriendshipStatus;
 import backend.drawrace.domain.user.entity.User;
+import backend.drawrace.domain.user.repository.FriendshipRepository;
 import backend.drawrace.domain.user.repository.UserRepository;
 import backend.drawrace.global.exception.ServiceException;
 
@@ -38,6 +42,7 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final ParticipantRepository participantRepository;
     private final UserRepository userRepository;
+    private final FriendshipRepository friendshipRepository;
     private final RankingService rankingService;
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectProvider<AiChatService> aiChatServiceProvider;
@@ -521,6 +526,40 @@ public class RoomService {
                 .build();
 
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", hostNotice);
+    }
+
+    public void inviteFriend(Long roomId, Long inviterId, Long friendId) {
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new ServiceException("404-2", "방을 찾을 수 없습니다."));
+
+        if (!participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)) {
+            throw new ServiceException("403-2", "방 참여자만 초대할 수 있습니다.");
+        }
+
+        if (room.isPlaying()) {
+            throw new ServiceException("400-2", "게임 중에는 초대할 수 없습니다.");
+        }
+
+        if (room.getCurPlayers() >= room.getMaxPlayers()) {
+            throw new ServiceException("400-3", "방 인원이 초과되었습니다.");
+        }
+
+        User inviter = userRepository.findById(inviterId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
+        User friend = userRepository.findById(friendId).orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
+
+        Friendship friendship = friendshipRepository.findByUsers(inviter, friend)
+                .orElseThrow(() -> new ServiceException("403-3", "친구 관계가 아닙니다."));
+
+        if (friendship.getStatus() != FriendshipStatus.ACCEPTED) {
+            throw new ServiceException("403-3", "친구 관계가 아닙니다.");
+        }
+
+        if (participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, friendId)) {
+            throw new ServiceException("400-6", "이미 방에 참여 중인 친구입니다.");
+        }
+
+        messagingTemplate.convertAndSend(
+                "/sub/users/" + friendId + "/notifications",
+                new RoomInviteResponse(roomId, room.getTitle(), inviterId, inviter.getNickname()));
     }
 
     /*

--- a/src/main/java/backend/drawrace/global/security/StompHandler.java
+++ b/src/main/java/backend/drawrace/global/security/StompHandler.java
@@ -60,7 +60,8 @@ public class StompHandler implements ChannelInterceptor {
             SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
 
             if (roomId != null) {
-                boolean isParticipant = participantRepository.existsByRoomIdAndUserId_Id(roomId, securityUser.getUserId());
+                boolean isParticipant =
+                        participantRepository.existsByRoomIdAndUserId_Id(roomId, securityUser.getUserId());
                 if (!isParticipant) {
                     log.warn("인가되지 않은 구독 시도: 유저 {}, 방 {}", securityUser.getUserId(), roomId);
                     throw new ServiceException("403-1", "해당 방에 접근 권한이 없습니다.");

--- a/src/main/java/backend/drawrace/global/security/StompHandler.java
+++ b/src/main/java/backend/drawrace/global/security/StompHandler.java
@@ -78,14 +78,21 @@ public class StompHandler implements ChannelInterceptor {
     private Long extractRoomId(String destination) {
         try {
             if (destination == null || !destination.startsWith("/sub/rooms/")) return null;
-
-            // /sub/rooms/{roomId} 형식에서 숫자 추출
             String[] parts = destination.split("/");
-            if (parts.length >= 4) {
-                return Long.parseLong(parts[3]);
-            }
+            if (parts.length >= 4) return Long.parseLong(parts[3]);
         } catch (Exception e) {
             log.error("roomId 추출 실패: {}", destination);
+        }
+        return null;
+    }
+
+    private Long extractNotificationUserId(String destination) {
+        try {
+            if (destination == null || !destination.startsWith("/sub/users/")) return null;
+            String[] parts = destination.split("/");
+            if (parts.length >= 4) return Long.parseLong(parts[3]);
+        } catch (Exception e) {
+            log.error("userId 추출 실패: {}", destination);
         }
         return null;
     }

--- a/src/main/java/backend/drawrace/global/security/StompHandler.java
+++ b/src/main/java/backend/drawrace/global/security/StompHandler.java
@@ -49,25 +49,26 @@ public class StompHandler implements ChannelInterceptor {
 
         // 구독 시 권한 체크
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-            String destination = accessor.getDestination(); // 예: /sub/rooms/10/chat
+            String destination = accessor.getDestination();
             Long roomId = extractRoomId(destination);
+            Long notificationUserId = extractNotificationUserId(destination);
+
+            Authentication authentication = (Authentication) accessor.getUser();
+            if (authentication == null) {
+                throw new ServiceException("401-1", "인증 정보가 없습니다.");
+            }
+            SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
 
             if (roomId != null) {
-                // 현재 인증된 유저 정보 가져오기
-                Authentication authentication = (Authentication) accessor.getUser();
-                if (authentication == null) {
-                    throw new ServiceException("401-1", "인증 정보가 없습니다.");
-                }
-
-                SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
-                Long userId = securityUser.getUserId();
-
-                // DB에서 해당 유저가 이 방의 참여자인지 확인
-                boolean isParticipant = participantRepository.existsByRoomIdAndUserId_Id(roomId, userId);
-
+                boolean isParticipant = participantRepository.existsByRoomIdAndUserId_Id(roomId, securityUser.getUserId());
                 if (!isParticipant) {
-                    log.warn("인가되지 않은 구독 시도: 유저 {}, 방 {}", userId, roomId);
+                    log.warn("인가되지 않은 구독 시도: 유저 {}, 방 {}", securityUser.getUserId(), roomId);
                     throw new ServiceException("403-1", "해당 방에 접근 권한이 없습니다.");
+                }
+            } else if (notificationUserId != null) {
+                if (!securityUser.getUserId().equals(notificationUserId)) {
+                    log.warn("인가되지 않은 알림 채널 구독 시도: 유저 {}, 채널 {}", securityUser.getUserId(), notificationUserId);
+                    throw new ServiceException("403-2", "본인의 알림 채널만 구독할 수 있습니다.");
                 }
             }
         }

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -735,20 +735,24 @@ class RoomServiceTest {
         User inviter = createUser(inviterId, "초대자");
         User friend = createUser(friendId, "친구");
         Friendship friendship = Friendship.builder()
-                .requester(inviter).receiver(friend).status(FriendshipStatus.ACCEPTED).build();
+                .requester(inviter)
+                .receiver(friend)
+                .status(FriendshipStatus.ACCEPTED)
+                .build();
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId))
+                .willReturn(true);
         given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
         given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
         given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.of(friendship));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, friendId)).willReturn(false);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, friendId))
+                .willReturn(false);
 
         roomService.inviteFriend(roomId, inviterId, friendId);
 
-        verify(messagingTemplate).convertAndSend(
-                eq("/sub/users/" + friendId + "/notifications"),
-                any(RoomInviteResponse.class));
+        verify(messagingTemplate)
+                .convertAndSend(eq("/sub/users/" + friendId + "/notifications"), any(RoomInviteResponse.class));
     }
 
     @Test
@@ -761,7 +765,8 @@ class RoomServiceTest {
         Room room = createRoom(roomId, "테스트방", inviterId);
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(false);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId))
+                .willReturn(false);
 
         assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
                 .isInstanceOf(ServiceException.class)
@@ -779,7 +784,8 @@ class RoomServiceTest {
         setField(room, "isPlaying", true);
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId))
+                .willReturn(true);
 
         assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
                 .isInstanceOf(ServiceException.class)
@@ -797,7 +803,8 @@ class RoomServiceTest {
         setField(room, "curPlayers", (short) 4);
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId))
+                .willReturn(true);
 
         assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
                 .isInstanceOf(ServiceException.class)
@@ -816,7 +823,8 @@ class RoomServiceTest {
         User friend = createUser(friendId, "타인");
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId))
+                .willReturn(true);
         given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
         given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
         given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.empty());
@@ -837,10 +845,14 @@ class RoomServiceTest {
         User inviter = createUser(inviterId, "초대자");
         User friend = createUser(friendId, "대기중친구");
         Friendship friendship = Friendship.builder()
-                .requester(inviter).receiver(friend).status(FriendshipStatus.PENDING).build();
+                .requester(inviter)
+                .receiver(friend)
+                .status(FriendshipStatus.PENDING)
+                .build();
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId))
+                .willReturn(true);
         given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
         given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
         given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.of(friendship));
@@ -861,14 +873,19 @@ class RoomServiceTest {
         User inviter = createUser(inviterId, "초대자");
         User friend = createUser(friendId, "이미참여중친구");
         Friendship friendship = Friendship.builder()
-                .requester(inviter).receiver(friend).status(FriendshipStatus.ACCEPTED).build();
+                .requester(inviter)
+                .receiver(friend)
+                .status(FriendshipStatus.ACCEPTED)
+                .build();
 
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(eq(roomId), eq(inviterId))).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(eq(roomId), eq(inviterId)))
+                .willReturn(true);
         given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
         given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
         given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.of(friendship));
-        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(eq(roomId), eq(friendId))).willReturn(true);
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(eq(roomId), eq(friendId)))
+                .willReturn(true);
 
         assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
                 .isInstanceOf(ServiceException.class)

--- a/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/room/service/RoomServiceTest.java
@@ -26,6 +26,7 @@ import backend.drawrace.domain.room.dto.request.CreateRoomReq;
 import backend.drawrace.domain.room.dto.response.GetRoomListRes;
 import backend.drawrace.domain.room.dto.response.RankingRes;
 import backend.drawrace.domain.room.dto.response.RoomInfoRes;
+import backend.drawrace.domain.room.dto.response.RoomInviteResponse;
 import backend.drawrace.domain.room.dto.response.RoomUpdateResponse;
 import backend.drawrace.domain.room.entity.Participant;
 import backend.drawrace.domain.room.entity.Room;
@@ -34,8 +35,11 @@ import backend.drawrace.domain.room.repository.RoomRepository;
 import backend.drawrace.domain.round.repository.RoundParticipantRepository;
 import backend.drawrace.domain.round.repository.RoundRepository;
 import backend.drawrace.domain.round.repository.RoundSubmissionRepository;
+import backend.drawrace.domain.user.entity.Friendship;
+import backend.drawrace.domain.user.entity.FriendshipStatus;
 import backend.drawrace.domain.user.entity.User;
 import backend.drawrace.domain.user.entity.UserStats;
+import backend.drawrace.domain.user.repository.FriendshipRepository;
 import backend.drawrace.domain.user.repository.UserRepository;
 import backend.drawrace.global.exception.ServiceException;
 
@@ -50,6 +54,9 @@ class RoomServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
 
     @Mock
     private RankingService rankingService;
@@ -713,6 +720,159 @@ class RoomServiceTest {
         assertThat(result.get(0).nickname()).isEqualTo("DB유저");
 
         verify(participantRepository).findByRoomId(roomId);
+    }
+
+    // ===== inviteFriend() =====
+
+    @Test
+    @DisplayName("친구 초대 성공 - WebSocket 알림이 전송된다")
+    void inviteFriend_success() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+        User inviter = createUser(inviterId, "초대자");
+        User friend = createUser(friendId, "친구");
+        Friendship friendship = Friendship.builder()
+                .requester(inviter).receiver(friend).status(FriendshipStatus.ACCEPTED).build();
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
+        given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
+        given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.of(friendship));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, friendId)).willReturn(false);
+
+        roomService.inviteFriend(roomId, inviterId, friendId);
+
+        verify(messagingTemplate).convertAndSend(
+                eq("/sub/users/" + friendId + "/notifications"),
+                any(RoomInviteResponse.class));
+    }
+
+    @Test
+    @DisplayName("친구 초대 실패 - 방 참여자가 아니면 예외가 발생한다")
+    void inviteFriend_fail_notParticipant() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(false);
+
+        assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "403-2");
+    }
+
+    @Test
+    @DisplayName("친구 초대 실패 - 게임 중이면 예외가 발생한다")
+    void inviteFriend_fail_gamePlaying() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+        setField(room, "isPlaying", true);
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+
+        assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "400-2");
+    }
+
+    @Test
+    @DisplayName("친구 초대 실패 - 방 정원이 초과되면 예외가 발생한다")
+    void inviteFriend_fail_roomFull() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+        setField(room, "curPlayers", (short) 4);
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+
+        assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "400-3");
+    }
+
+    @Test
+    @DisplayName("친구 초대 실패 - 친구 관계가 아니면 예외가 발생한다")
+    void inviteFriend_fail_notFriend() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+        User inviter = createUser(inviterId, "초대자");
+        User friend = createUser(friendId, "타인");
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
+        given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
+        given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "403-3");
+    }
+
+    @Test
+    @DisplayName("친구 초대 실패 - PENDING 상태 친구는 초대할 수 없다")
+    void inviteFriend_fail_pendingFriendship() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+        User inviter = createUser(inviterId, "초대자");
+        User friend = createUser(friendId, "대기중친구");
+        Friendship friendship = Friendship.builder()
+                .requester(inviter).receiver(friend).status(FriendshipStatus.PENDING).build();
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(roomId, inviterId)).willReturn(true);
+        given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
+        given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
+        given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.of(friendship));
+
+        assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "403-3");
+    }
+
+    @Test
+    @DisplayName("친구 초대 실패 - 이미 방에 참여 중인 친구는 초대할 수 없다")
+    void inviteFriend_fail_friendAlreadyInRoom() throws Exception {
+        Long roomId = 1L;
+        Long inviterId = 1L;
+        Long friendId = 2L;
+
+        Room room = createRoom(roomId, "테스트방", inviterId);
+        User inviter = createUser(inviterId, "초대자");
+        User friend = createUser(friendId, "이미참여중친구");
+        Friendship friendship = Friendship.builder()
+                .requester(inviter).receiver(friend).status(FriendshipStatus.ACCEPTED).build();
+
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(eq(roomId), eq(inviterId))).willReturn(true);
+        given(userRepository.findById(inviterId)).willReturn(Optional.of(inviter));
+        given(userRepository.findById(friendId)).willReturn(Optional.of(friend));
+        given(friendshipRepository.findByUsers(inviter, friend)).willReturn(Optional.of(friendship));
+        given(participantRepository.existsByRoomIdAndUserId_IdAndIsLeftFalse(eq(roomId), eq(friendId))).willReturn(true);
+
+        assertThatThrownBy(() -> roomService.inviteFriend(roomId, inviterId, friendId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "400-6");
     }
 
     private Room createRoom(Long id, String title, Long hostId) throws Exception {


### PR DESCRIPTION
## 📝 작업 내용
- 방 참여자가 친구 목록에서 친구를 선택해 초대 알림을 보낼 수 있는 기능을 추가
  - POST /api/rooms/{roomId}/invite/{friendId} 엔드포인트 추가
  - 초대 전송 시 WebSocket으로 /sub/users/{friendId}/notifications 채널에 RoomInviteResponse 전달
  - 유효성 검사: 방 참여자 여부, 게임 중 여부, 정원 초과 여부, 친구 관계(ACCEPTED) 여부, 친구의 방 중복 참여 여부
  - StompHandler에 /sub/users/{userId}/notifications 구독 권한 체크 추가 (본인 채널만 구독 가능)

## 🔢 작업 단계
- [ ] RoomInviteResponse DTO 생성
- [ ] RoomService.inviteFriend() — 유효성 검사 및 WebSocket 알림 전송 구현
- [ ] RoomController — 친구 초대 엔드포인트 추가
- [ ] StompHandler — 알림 채널 구독 권한 체크 추가
- [ ] 테스트 코드 작성

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #89 