### PR TITLE
fix: AI Gateway 요청에 max_tokens 추가

### DIFF
--- a/src/main/java/backend/drawrace/domain/round/dto/gateway/GatewayChatRequest.java
+++ b/src/main/java/backend/drawrace/domain/round/dto/gateway/GatewayChatRequest.java
@@ -3,16 +3,23 @@ package backend.drawrace.domain.round.dto.gateway;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class GatewayChatRequest {
 
     private String model;
     private List<Message> messages;
     private double temperature;
+
+    @JsonProperty("max_tokens")
+    private Integer maxTokens;
 
     @Getter
     @Builder

--- a/src/main/java/backend/drawrace/domain/round/service/GatewayAiInferenceService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/GatewayAiInferenceService.java
@@ -61,6 +61,7 @@ public class GatewayAiInferenceService implements AiInferenceService {
         GatewayChatRequest request = GatewayChatRequest.builder()
                 .model(aiProperties.model())
                 .temperature(0.2)
+                .maxTokens(1024)
                 .messages(List.of(
                         GatewayChatRequest.systemMessage(buildSystemPrompt()),
                         GatewayChatRequest.userMessage(List.of(


### PR DESCRIPTION
## 📝 작업 내용
- GatewayChatRequest에 max_tokens 필드가 없어서 litellm이 GLM-4.5-flash로 요청을 프록시할 때 "Invalid API parameter" 에러 반환

## 🔢 작업 단계
- [ ] AI Gateway 요청에 max_tokens 추가

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #