### PR TITLE
[Feat] 채팅금지 기능 추가 및 버그 수정

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
+++ b/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
@@ -43,6 +43,10 @@ public class ChatController {
                 .findById(securityUser.getUserId())
                 .orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
 
+        // 메시지마다 고유 ID 생성
+        String messageId = java.util.UUID.randomUUID().toString();
+        chatMessage.setMessageId(messageId);
+
         // AI 검열 실행
         String filteredMessage = chatModerationService.fastFilter(securityUser.getUserId(), chatMessage.getMessage());
 
@@ -55,6 +59,6 @@ public class ChatController {
         chatMessage.setType(ChatMessageDto.MessageType.TALK);
         messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);
 
-        chatModerationService.processAiModeration(roomId, chatMessage);
+        chatModerationService.processAiModeration(securityUser.getUserId(), roomId, chatMessage);
     }
 }

--- a/src/main/java/backend/drawrace/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/backend/drawrace/domain/chat/dto/ChatMessageDto.java
@@ -19,4 +19,5 @@ public class ChatMessageDto {
     private Long roomId;
     private String sender; // 보낸 사람 닉네임 (시스템 메시지는 "System")
     private String message;
+    private String messageId;
 }

--- a/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.PostConstruct;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,7 @@ public class ChatModerationService {
     private final RestClient restClient;
     private final SimpMessagingTemplate messagingTemplate;
     private final EmbeddingService embeddingService;
+    private final StringRedisTemplate redisTemplate;
 
     private final Map<Long, LastChatInfo> chatHistory = new ConcurrentHashMap<>();
     private final List<float[]> aggressiveVectors = new ArrayList<>();
@@ -58,6 +61,12 @@ public class ChatModerationService {
     }
 
     public String fastFilter(Long userId, String originalMessage) {
+
+        // 차단 여부 확인
+        if (isUserBanned(userId)) {
+            throw new ServiceException("403-3", "부적절한 언어 사용으로 인해 3일간 채팅이 금지되었습니다.");
+        }
+
         // 도배 체크
         checkSpam(userId, originalMessage);
 
@@ -68,6 +77,11 @@ public class ChatModerationService {
         // 키워드 기반 즉시 차단
         if (originalMessage.matches(BANNED_PATTERN)) {
             return "****"; // 욕설 발견 시 즉시 마스킹
+        }
+
+        // 짧은 문장은 임베딩 검사 패스
+        if (originalMessage.length() < 3) {
+            return originalMessage;
         }
 
         // 임베딩 유사도 체크
@@ -86,7 +100,7 @@ public class ChatModerationService {
     }
 
     @Async("taskExecutor")
-    public void processAiModeration(Long roomId, ChatMessageDto chatMessage) {
+    public void processAiModeration(Long userId, Long roomId, ChatMessageDto chatMessage) {
         try {
 
             String aiResult = getAiDecisionStrict(chatMessage.getMessage());
@@ -95,10 +109,33 @@ public class ChatModerationService {
                 // 부적절하다고 판단되면 메시지를 교체하고 다시 브로드캐스트
                 chatMessage.setMessage("[AI 검열에 의해 삭제된 메시지입니다]");
                 messagingTemplate.convertAndSend("/sub/rooms/" + roomId + "/chat", chatMessage);
+
+                applyStrikeAndCheckBan(userId);
+
                 log.info("AI가 부적절한 메시지 감지 및 수정 완료: {}", chatMessage.getMessage());
             }
         } catch (Exception e) {
             log.error("비동기 AI 검열 중 오류 발생: {}", e.getMessage());
+        }
+    }
+
+    private void applyStrikeAndCheckBan(Long userId) {
+        String strikeKey = "strike:user:" + userId;
+        String banKey = "ban:user:" + userId;
+
+        // 스트라이크 1 증가
+        Long currentStrikes = redisTemplate.opsForValue().increment(strikeKey);
+
+        // 첫 적발 시 24시간 후 스트라이크 초기화 설정
+        if (currentStrikes != null && currentStrikes == 1) {
+            redisTemplate.expire(strikeKey, 24, TimeUnit.HOURS);
+        }
+
+        // 3회 적발 시 3일간 차단
+        if (currentStrikes != null && currentStrikes >= 3) {
+            redisTemplate.opsForValue().set(banKey, "BANNED", 3, TimeUnit.DAYS);
+            redisTemplate.delete(strikeKey); // 차단됐으니 스트라이크는 삭제
+            log.info("유저 {}님 3회 적발로 3일간 채팅 금지", userId);
         }
     }
 
@@ -140,13 +177,36 @@ public class ChatModerationService {
 
         if (last != null) {
             if (now - last.timestamp < SPAM_LIMIT_MS) throw new ServiceException("429-1", "채팅이 너무 빠릅니다.");
-            if (last.message.equals(message)) throw new ServiceException("429-2", "동일한 내용의 채팅입니다.");
+            if (last.message.equals(message)) {
+                last.repeatCount++;
+                if (last.repeatCount > 10) {
+                    throw new ServiceException("429-2", "동일한 내용의 채팅입니다.");
+                }
+            } else {
+                last.repeatCount = 1;
+            }
+            last.timestamp = now;
+            last.message = message;
+        } else {
+            chatHistory.put(userId, new LastChatInfo(message, now, 1));
         }
-        chatHistory.put(userId, new LastChatInfo(message, now));
     }
 
-    private record LastChatInfo(String message, long timestamp) {}
+    private boolean isUserBanned(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey("ban:user:" + userId));
+    }
 
+    private static class LastChatInfo {
+        String message;
+        long timestamp;
+        int repeatCount;
+
+        LastChatInfo(String message, long timestamp, int repeatCount) {
+            this.message = message;
+            this.timestamp = timestamp;
+            this.repeatCount = repeatCount;
+        }
+    }
     /*
     private final Map<Long, LastChatInfo> chatHistory = new ConcurrentHashMap<>();
     private static final int SPAM_LIMIT_MS = 1000;

--- a/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/controller/ChatControllerTest.java
@@ -130,6 +130,6 @@ class ChatControllerTest {
 
         verify(messagingTemplate).convertAndSend(eq("/sub/rooms/" + roomId + "/chat"), any(ChatMessageDto.class));
 
-        verify(chatModerationService).processAiModeration(eq(roomId), any(ChatMessageDto.class));
+        verify(chatModerationService).processAiModeration(anyLong(), eq(roomId), any(ChatMessageDto.class));
     }
 }

--- a/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/chat/service/ChatModerationServiceTest.java
@@ -1,7 +1,11 @@
 package backend.drawrace.domain.chat.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,9 +14,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import backend.drawrace.global.config.AiProperties;
+import backend.drawrace.global.exception.ServiceException;
 
 @ExtendWith(MockitoExtension.class)
 class ChatModerationServiceTest {
@@ -29,6 +37,12 @@ class ChatModerationServiceTest {
     @Spy
     @InjectMocks
     private ChatModerationService chatModerationService;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
 
     /*
        @Test
@@ -57,6 +71,64 @@ class ChatModerationServiceTest {
        }
 
     */
+
+    @Test
+    @DisplayName("3자 미만의 짧은 문장(ㅎㅇ, ㅇㅇ)은 임베딩 검사를 건너뛰고 통과한다")
+    void shouldPassShortMessagesWithoutEmbedding() {
+        Long userId = 1L;
+        String shortMessage = "띠용"; // 3자 미만
+
+        String result = chatModerationService.fastFilter(userId, shortMessage);
+
+        assertThat(result).isEqualTo(shortMessage);
+        verify(embeddingService, never()).embed(anyString());
+    }
+
+    @Test
+    @DisplayName("첫 번째 적발 시 스트라이크가 1 증가하고 24시간 제한이 걸린다")
+    void shouldIncreaseStrikeAndSetExpiryOnFirstOffense() {
+        Long userId = 1L;
+        String strikeKey = "strike:user:" + userId;
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(strikeKey)).thenReturn(1L); // 첫 번째 적발 시뮬레이션
+
+        ReflectionTestUtils.invokeMethod(chatModerationService, "applyStrikeAndCheckBan", userId);
+
+        verify(valueOperations).increment(strikeKey);
+        verify(redisTemplate).expire(eq(strikeKey), eq(24L), eq(TimeUnit.HOURS));
+    }
+
+    @Test
+    @DisplayName("스트라이크가 3회 누적되면 3일간 차단되고 스트라이크 기록이 삭제된다")
+    void shouldBanUserFor3DaysOnThirdOffense() {
+        Long userId = 1L;
+        String strikeKey = "strike:user:" + userId;
+        String banKey = "ban:user:" + userId;
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(strikeKey)).thenReturn(3L); // 3회 적발 시뮬레이션
+
+        ReflectionTestUtils.invokeMethod(chatModerationService, "applyStrikeAndCheckBan", userId);
+
+        verify(valueOperations).set(eq(banKey), eq("BANNED"), eq(3L), eq(TimeUnit.DAYS));
+        verify(redisTemplate).delete(strikeKey);
+    }
+
+    @Test
+    @DisplayName("차단된 유저가 채팅을 시도하면 403 예외가 발생한다")
+    void fastFilter_ShouldThrowException_WhenUserIsBanned() {
+        Long userId = 1L;
+        String message = "안녕하세요";
+        when(redisTemplate.hasKey("ban:user:" + userId)).thenReturn(true);
+
+        ServiceException exception = assertThrows(ServiceException.class, () -> {
+            chatModerationService.fastFilter(userId, message);
+        });
+
+        assertEquals("403-3", exception.getResultCode());
+        assertTrue(exception.getMessage().contains("채팅이 금지되었습니다"));
+    }
 
     @Test
     @DisplayName("임베딩 유사도가 높으면 부적절한 메시지로 판정한다")


### PR DESCRIPTION
## 📝 작업 내용
- 채팅 서비스의 안정성을 높이고, 실제 사용자 환경에서 발생한 오탐 및 UI 동기화 문제를 해결하기 위해 다음의 기능들을 구현 및 수정했습니다.

## 🔢 작업 단계
- [ ] fastFilter 최상단에서 차단 여부를 즉시 확인하여 제재 중인 유저의 채팅을 차단합니다.
- [ ] ChatController에서 채팅 수신 즉시 UUID를 생성합니다.
- [ ] 자 미만의 짧은 메시지(ㅎㅇ, ㅇㅇ, 띠용 등)는 임베딩 검사에서 제외하여 일상 대화가 가려지지 않도록 보호합니다.
- [ ] 

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #95 