### PR TITLE
Fix: 라운드 동시 제출 종료 판정 안정화

### DIFF
--- a/src/main/java/backend/drawrace/domain/round/repository/RoundRepository.java
+++ b/src/main/java/backend/drawrace/domain/round/repository/RoundRepository.java
@@ -2,7 +2,10 @@ package backend.drawrace.domain.round.repository;
 
 import java.util.Optional;
 
+import jakarta.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +14,13 @@ import backend.drawrace.domain.round.entity.Round;
 
 public interface RoundRepository extends JpaRepository<Round, Long> {
     Optional<Round> findByRoomIdAndIsActiveTrue(Long roomId);
+
+    /**
+     * 그림 제출 저장·집계 직전에 호출한다. 동시에 제출할 때 submittedCount 레이스를 막기 위한 배타 락.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from Round r join fetch r.room where r.id = :id")
+    Optional<Round> findByIdForUpdate(@Param("id") Long id);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Round r WHERE r.room.id = :roomId")

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -206,8 +206,8 @@ public class RoundService {
             roundValidator.validateParticipantOwner(lockedParticipant, userId);
         }
 
-        boolean canPlayLocked =
-                roundParticipantRepository.existsByRoundIdAndParticipantId(lockedRound.getId(), lockedParticipant.getId());
+        boolean canPlayLocked = roundParticipantRepository.existsByRoundIdAndParticipantId(
+                lockedRound.getId(), lockedParticipant.getId());
         roundValidator.validateRoundParticipant(canPlayLocked);
 
         boolean alreadySubmittedLocked = roundSubmissionRepository.existsByRoundIdAndParticipantId(
@@ -240,7 +240,8 @@ public class RoundService {
         }
 
         // 전원 제출 완료 시 라운드 종료 처리
-        SubmitDrawingResponse response = handleRoundCompletion(lockedRound, aiResult, submittedCount, totalParticipantCount);
+        SubmitDrawingResponse response =
+                handleRoundCompletion(lockedRound, aiResult, submittedCount, totalParticipantCount);
 
         if (response.isRoundFinished()) {
             Long roomId = lockedRound.getRoom().getId();

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -186,21 +186,49 @@ public class RoundService {
             aiResult = aiInferenceService.infer(request.getImageData(), round.getKeyword());
         }
 
+        /*
+         * 동시 제출: infer는 네트워크 I/O로 길어 락 밖에서 수행하고,
+         * 저장·count·라운드 종료 판정 전에 라운드 행에 배타 락을 걸어 submittedCount 레이스를 방지한다.
+         */
+        Round lockedRound = roundRepository
+                .findByIdForUpdate(roundId)
+                .orElseThrow(() -> new ServiceException("404-2", "존재하지 않는 라운드입니다."));
+
+        roundValidator.validateRoundInProgress(lockedRound);
+
+        Participant lockedParticipant = getValidParticipant(lockedRound, request.getParticipantId());
+
+        if (lockedParticipant.isLeft()) {
+            throw new ServiceException("403-6", "이미 퇴장한 참가자는 제출할 수 없습니다.");
+        }
+
+        if (!lockedParticipant.getUserId().isAi()) {
+            roundValidator.validateParticipantOwner(lockedParticipant, userId);
+        }
+
+        boolean canPlayLocked =
+                roundParticipantRepository.existsByRoundIdAndParticipantId(lockedRound.getId(), lockedParticipant.getId());
+        roundValidator.validateRoundParticipant(canPlayLocked);
+
+        boolean alreadySubmittedLocked = roundSubmissionRepository.existsByRoundIdAndParticipantId(
+                lockedRound.getId(), lockedParticipant.getId());
+        roundValidator.validateNotSubmitted(alreadySubmittedLocked);
+
         // 제출 기록 저장
         RoundSubmission submission = RoundSubmission.create(
-                round, participant, request.getImageData(), aiResult.getAiAnswer(), aiResult.getScore());
+                lockedRound, lockedParticipant, request.getImageData(), aiResult.getAiAnswer(), aiResult.getScore());
         roundSubmissionRepository.save(submission);
 
         // 전원 제출 기준은 퇴장하지 않은 참가자만 대상으로 한다.
-        long submittedCount = roundSubmissionRepository.countActiveByRoundId(round.getId());
-        long totalParticipantCount = roundParticipantRepository.countActiveByRoundId(round.getId());
+        long submittedCount = roundSubmissionRepository.countActiveByRoundId(lockedRound.getId());
+        long totalParticipantCount = roundParticipantRepository.countActiveByRoundId(lockedRound.getId());
 
-        sendPlayerSubmittedEvent(round, participant, submittedCount, totalParticipantCount);
+        sendPlayerSubmittedEvent(lockedRound, lockedParticipant, submittedCount, totalParticipantCount);
 
         // 아직 전원 제출 전이면 대기 응답 반환
         if (submittedCount < totalParticipantCount) {
             return SubmitDrawingResponse.builder()
-                    .roundId(round.getId())
+                    .roundId(lockedRound.getId())
                     .submittedAiAnswer(aiResult.getAiAnswer())
                     .submittedScore(aiResult.getScore())
                     .submittedCount((int) submittedCount)
@@ -212,10 +240,10 @@ public class RoundService {
         }
 
         // 전원 제출 완료 시 라운드 종료 처리
-        SubmitDrawingResponse response = handleRoundCompletion(round, aiResult, submittedCount, totalParticipantCount);
+        SubmitDrawingResponse response = handleRoundCompletion(lockedRound, aiResult, submittedCount, totalParticipantCount);
 
         if (response.isRoundFinished()) {
-            Long roomId = round.getRoom().getId();
+            Long roomId = lockedRound.getRoom().getId();
             // 구독 경로: /sub/rooms/{roomId} 로 결과 전송
             messagingTemplate.convertAndSend("/sub/rooms/" + roomId, response);
         }

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -758,7 +758,6 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
-        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -802,7 +801,6 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
-        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
 
         assertThatThrownBy(() -> roundService.submitDrawing(roundId, 1L, request))
@@ -876,7 +874,6 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
-        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
 
         willThrow(new ServiceException("403-3", "본인 참가 정보로만 제출할 수 있습니다."))

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -216,6 +216,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -259,6 +260,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -301,6 +303,7 @@ class RoundServiceTest {
         RoundSubmission otherSubmission = RoundSubmission.create(round, participant2, "other-image", "사과", 0.70);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -359,6 +362,7 @@ class RoundServiceTest {
         RoundSubmission submission = RoundSubmission.create(round, participant, "dummy-image", "사과", 0.95);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -403,6 +407,7 @@ class RoundServiceTest {
         RoundSubmission winnerSubmission = RoundSubmission.create(round, winnerParticipant, "winner-image", "사과", 0.95);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -475,6 +480,7 @@ class RoundServiceTest {
         setCreatedAt(currentSubmission, LocalDateTime.of(2026, 1, 1, 10, 1));
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -543,6 +549,7 @@ class RoundServiceTest {
         RoundSubmission otherSubmission = RoundSubmission.create(round, participant2, "other-image", "사과", 0.81);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -591,6 +598,7 @@ class RoundServiceTest {
         RoundSubmission otherSubmission = RoundSubmission.create(round, participant2, "other-image", "사과", 0.60);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -649,6 +657,7 @@ class RoundServiceTest {
         RoundSubmission otherSubmission = RoundSubmission.create(round, participant2, "other-image", "사과", 0.71);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -701,6 +710,7 @@ class RoundServiceTest {
         setCreatedAt(currentSubmission, LocalDateTime.of(2026, 1, 1, 10, 1));
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -748,6 +758,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);
@@ -791,6 +802,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
 
         assertThatThrownBy(() -> roundService.submitDrawing(roundId, 1L, request))
@@ -864,6 +876,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(participantId, "dummy-image");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
 
         willThrow(new ServiceException("403-3", "본인 참가 정보로만 제출할 수 있습니다."))
@@ -904,6 +917,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(aiParticipantId, "stroke-json");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(aiParticipantId, roomId)).willReturn(Optional.of(aiParticipant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId))
                 .willReturn(true);
@@ -934,6 +948,7 @@ class RoundServiceTest {
         SubmitDrawingRequest request = createSubmitDrawingRequest(aiParticipantId, "stroke-json");
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(aiParticipantId, roomId)).willReturn(Optional.of(aiParticipant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, aiParticipantId))
                 .willReturn(true);
@@ -1097,6 +1112,7 @@ class RoundServiceTest {
         RoundSubmission submission = RoundSubmission.create(round, participant, "dummy-image", "사과", 0.95);
 
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(roundRepository.findByIdForUpdate(roundId)).willReturn(Optional.of(round));
         given(participantRepository.findByIdAndRoomId(participantId, roomId)).willReturn(Optional.of(participant));
         given(roundParticipantRepository.existsByRoundIdAndParticipantId(roundId, participantId))
                 .willReturn(true);

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceWebSocketTest.java
@@ -97,6 +97,7 @@ class RoundServiceWebSocketTest {
         lenient().when(round.getRoundNumber()).thenReturn(1);
         lenient().when(round.getKeyword()).thenReturn("강아지");
         lenient().when(roundRepository.findById(roundId)).thenReturn(Optional.of(round));
+        lenient().when(roundRepository.findByIdForUpdate(roundId)).thenReturn(Optional.of(round));
 
         Participant participant = mock(Participant.class);
         lenient().when(participant.getId()).thenReturn(participantId);
@@ -157,6 +158,7 @@ class RoundServiceWebSocketTest {
         lenient().when(round.getRoundNumber()).thenReturn(1);
         lenient().when(round.getKeyword()).thenReturn("사과");
         lenient().when(roundRepository.findById(roundId)).thenReturn(Optional.of(round));
+        lenient().when(roundRepository.findByIdForUpdate(roundId)).thenReturn(Optional.of(round));
 
         Participant participant = mock(Participant.class);
         lenient().when(participant.getId()).thenReturn(participantId);


### PR DESCRIPTION
## 📌 작업 개요

동시에 여러 참가자가 그림을 제출했을 때 라운드 종료 판정이 누락되는 문제를 수정했습니다.

기존에는 각 제출 요청이 `save → count → roundFinished 판단`을 락 없이 수행하고 있었습니다.  
그 결과 두 명이 거의 동시에 제출하면 각각의 트랜잭션에서 서로의 제출을 보지 못하고 둘 다 `submittedCount=1`, `roundFinished=false`로 응답하는 레이스 컨디션이 발생할 수 있었습니다.

이번 수정에서는 AI 판별은 기존처럼 병렬로 수행하되, 실제 DB 저장과 제출 수 집계, 라운드 종료 판정 구간만 `roundId` 기준으로 직렬화되도록 `PESSIMISTIC_WRITE` 락을 적용했습니다.

---

## ✅ 주요 변경 사항

### 1. `RoundRepository`에 락 조회 메서드 추가

라운드 제출 저장/집계 구간에서 같은 라운드에 대한 동시 처리를 막기 위해 `findByIdForUpdate()`를 추가했습니다.

```java
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("""
    select r
    from Round r
    join fetch r.room
    where r.id = :id
    """)
Optional<Round> findByIdForUpdate(@Param("id") Long id);