### PR TITLE
[Fix] 채팅 검열 로직 개선 및 타이머 로직 강화

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
+++ b/src/main/java/backend/drawrace/domain/chat/service/ChatModerationService.java
@@ -70,17 +70,17 @@ public class ChatModerationService {
         // 도배 체크
         checkSpam(userId, originalMessage);
 
-        String normalized = originalMessage.replaceAll("[^가-힣]", "");
+        String normalized = originalMessage.replaceAll("[^가-힣ㄱ-ㅎㅏ-ㅣ]", "");
 
-        String BANNED_PATTERN = ".*(시발|ㅅㅂ|씨발|병신|ㅂㅅ|새끼|야발|지랄|니미|느금|ㅗ).*";
+        String BANNED_PATTERN = ".*(시발|ㅅㅂ|씨발|병신|ㅂㅅ|새끼|야발|지랄|니미|느금|ㅗ|시바|ㅅ1ㅂ).*";
 
         // 키워드 기반 즉시 차단
-        if (originalMessage.matches(BANNED_PATTERN)) {
+        if (originalMessage.matches(BANNED_PATTERN) || normalized.matches(BANNED_PATTERN)) {
             return "****"; // 욕설 발견 시 즉시 마스킹
         }
 
         // 짧은 문장은 임베딩 검사 패스
-        if (originalMessage.length() < 3) {
+        if (originalMessage.trim().length() < 3) {
             return originalMessage;
         }
 

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -135,13 +135,9 @@ public class RoundService {
         // 구독 경로: /sub/rooms/{roomId}
         messagingTemplate.convertAndSend(
                 "/sub/rooms/" + round.getRoom().getId(),
-                GameEvent.builder()
-                        .type("TIME_OVER")
-                        .data(roundId)
-                        .build());
+                GameEvent.builder().type("TIME_OVER").data(roundId).build());
 
-        taskScheduler.schedule(() -> forceFinishRound(roundId),
-                Instant.now().plusSeconds(5));
+        taskScheduler.schedule(() -> forceFinishRound(roundId), Instant.now().plusSeconds(5));
     }
 
     @Transactional
@@ -156,8 +152,7 @@ public class RoundService {
         List<RoundParticipant> rpList = roundParticipantRepository.findActiveByRoundId(round.getId());
 
         // 이미 제출한 사람들의 참가자 ID 목록
-        List<Long> submittedParticipantIds = roundSubmissionRepository.findByRoundId(round.getId())
-                .stream()
+        List<Long> submittedParticipantIds = roundSubmissionRepository.findByRoundId(round.getId()).stream()
                 .map(s -> s.getParticipant().getId())
                 .toList();
 
@@ -169,12 +164,8 @@ public class RoundService {
                 // 🚀 RoundSubmission.create 파라미터 순서 및 타입 수정
                 // 순서: Round, Participant, imageData, aiAnswer, score
                 RoundSubmission fallback = RoundSubmission.create(
-                        round,
-                        participant,
-                        "{}",
-                        "TIMEOUT",
-                        0.0         // 점수는 0점
-                );
+                        round, participant, "{}", "TIMEOUT", 0.0 // 점수는 0점
+                        );
                 roundSubmissionRepository.save(fallback);
             }
         }

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -136,9 +136,59 @@ public class RoundService {
         messagingTemplate.convertAndSend(
                 "/sub/rooms/" + round.getRoom().getId(),
                 GameEvent.builder()
-                        .type("TIME_OVER") // 이벤트 타입 정의[cite: 12]
+                        .type("TIME_OVER")
                         .data(roundId)
                         .build());
+
+        taskScheduler.schedule(() -> forceFinishRound(roundId),
+                Instant.now().plusSeconds(5));
+    }
+
+    @Transactional
+    public synchronized void forceFinishRound(Long roundId) {
+        Round round = roundRepository.findById(roundId).orElse(null);
+        // 이미 모두 제출해서 종료되었거나 라운드가 없으면 무시
+        if (round == null || round.getStatus() != RoundStatus.IN_PROGRESS) return;
+
+        log.info("⏰ 5초 대기 종료. 미제출자 강제 0점 처리 시작: roundId={}", roundId);
+
+        // 이번 라운드에 참여한 모든 참가자 목록
+        List<RoundParticipant> rpList = roundParticipantRepository.findActiveByRoundId(round.getId());
+
+        // 이미 제출한 사람들의 참가자 ID 목록
+        List<Long> submittedParticipantIds = roundSubmissionRepository.findByRoundId(round.getId())
+                .stream()
+                .map(s -> s.getParticipant().getId())
+                .toList();
+
+        for (RoundParticipant rp : rpList) {
+            Participant participant = rp.getParticipant(); // 👈 RoundParticipant에서 Participant 추출
+
+            // 제출 안 했고, 방을 나가지 않은 유저만 강제 제출 처리
+            if (!submittedParticipantIds.contains(participant.getId()) && !participant.isLeft()) {
+                // 🚀 RoundSubmission.create 파라미터 순서 및 타입 수정
+                // 순서: Round, Participant, imageData, aiAnswer, score
+                RoundSubmission fallback = RoundSubmission.create(
+                        round,
+                        participant,
+                        "{}",
+                        "TIMEOUT",
+                        0.0         // 점수는 0점
+                );
+                roundSubmissionRepository.save(fallback);
+            }
+        }
+
+        long count = roundSubmissionRepository.countActiveByRoundId(round.getId());
+
+        AiInferenceResponse dummyResult = new AiInferenceResponse(round.getKeyword(), 0.0);
+
+        SubmitDrawingResponse response = handleRoundCompletion(round, dummyResult, count, count);
+
+        // 결과 브로드캐스트
+        if (response.isRoundFinished()) {
+            messagingTemplate.convertAndSend("/sub/rooms/" + round.getRoom().getId(), response);
+        }
     }
 
     /**

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -62,7 +62,7 @@ public class RoundService {
     private final ObjectProvider<AiSubmissionService> aiSubmissionServiceProvider;
     private final ObjectProvider<AiChatService> aiChatServiceProvider;
     private final TaskScheduler taskScheduler;
-    private static final int ROUND_TIME_LIMIT = 60;
+    private static final int ROUND_TIME_LIMIT = 90;
     private final RoomService roomService;
     private final RankingService rankingService;
 

--- a/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/RoundServiceTest.java
@@ -138,7 +138,7 @@ class RoundServiceTest {
         assertThat(response.getStartedAt()).isNotNull();
 
         // 라운드 제한 시간 60초 확인
-        assertThat(response.getTimeLimit()).isEqualTo(60);
+        assertThat(response.getTimeLimit()).isEqualTo(90);
 
         assertThat(room.isPlaying()).isTrue();
 


### PR DESCRIPTION
## 📝 작업 내용
- 채팅 검열의 빈틈을 보완하고, 라운드 종료 시 미제출자로 인해 게임이 멈추는 현상을 방지하기 위해 강제 제출 로직을 도입했습니다.

## 🔢 작업 단계
- [ ]  숫자나 특수문자가 섞인 욕설(예: ㅅ1ㅂ)을 감지하기 위해 정규화(Normalization) 과정에서 초성(ㄱ-ㅎ)과 모음까지 인식하도록 정규식을 수정했습니다.
- [ ] 네트워크 지연을 고려해 5초 뒤 서버에서 forceFinishRound를 실행, 이때까지 제출하지 않은 유저는 현재까지의 데이터(혹은 폴백 데이터)로 강제 마감 처리합니다.

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #