### PR TITLE
feat: AI 판별 요청 동시성 제한

### DIFF
--- a/src/main/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceService.java
@@ -35,12 +35,8 @@ public class ConcurrentLimitedAiInferenceService implements AiInferenceService {
             if (acquireTimeoutSeconds <= 0) {
                 semaphore.acquireUninterruptibly();
             } else if (!semaphore.tryAcquire(acquireTimeoutSeconds, TimeUnit.SECONDS)) {
-                log.warn(
-                        "AI 판별 세마포어 대기 시간 초과. keyword={}, timeoutSec={}",
-                        keyword,
-                        acquireTimeoutSeconds);
-                throw new ServiceException(
-                        "503-1", "AI 판별 대기 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.");
+                log.warn("AI 판별 세마포어 대기 시간 초과. keyword={}, timeoutSec={}", keyword, acquireTimeoutSeconds);
+                throw new ServiceException("503-1", "AI 판별 대기 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.");
             }
             acquired = true;
             return delegate.infer(imageData, keyword);

--- a/src/main/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceService.java
@@ -1,0 +1,56 @@
+package backend.drawrace.domain.round.service;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import backend.drawrace.domain.round.dto.AiInferenceResponse;
+import backend.drawrace.global.exception.ServiceException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 외부 AI 게이트웨이 동시 호출 수를 제한한다. 동시 제출이 몰려도 호출 폭주를 막는다.
+ */
+@Slf4j
+public class ConcurrentLimitedAiInferenceService implements AiInferenceService {
+
+    private final AiInferenceService delegate;
+    private final Semaphore semaphore;
+    private final long acquireTimeoutSeconds;
+
+    public ConcurrentLimitedAiInferenceService(
+            AiInferenceService delegate, int maxConcurrent, long acquireTimeoutSeconds) {
+        if (maxConcurrent < 1) {
+            throw new IllegalArgumentException("maxConcurrent must be >= 1");
+        }
+        this.delegate = delegate;
+        this.semaphore = new Semaphore(maxConcurrent, true);
+        this.acquireTimeoutSeconds = acquireTimeoutSeconds;
+    }
+
+    @Override
+    public AiInferenceResponse infer(String imageData, String keyword) {
+        boolean acquired = false;
+        try {
+            if (acquireTimeoutSeconds <= 0) {
+                semaphore.acquireUninterruptibly();
+            } else if (!semaphore.tryAcquire(acquireTimeoutSeconds, TimeUnit.SECONDS)) {
+                log.warn(
+                        "AI 판별 세마포어 대기 시간 초과. keyword={}, timeoutSec={}",
+                        keyword,
+                        acquireTimeoutSeconds);
+                throw new ServiceException(
+                        "503-1", "AI 판별 대기 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.");
+            }
+            acquired = true;
+            return delegate.infer(imageData, keyword);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ServiceException("500-1", "AI 판별에 실패했습니다. 다시 시도해주세요.");
+        } finally {
+            if (acquired) {
+                semaphore.release();
+            }
+        }
+    }
+}

--- a/src/main/java/backend/drawrace/global/config/AiInferenceConcurrencyConfiguration.java
+++ b/src/main/java/backend/drawrace/global/config/AiInferenceConcurrencyConfiguration.java
@@ -20,7 +20,6 @@ public class AiInferenceConcurrencyConfiguration {
             GatewayAiInferenceService gatewayAiInferenceService,
             @Value("${ai.inference.max-concurrent:4}") int maxConcurrent,
             @Value("${ai.inference.acquire-timeout-seconds:120}") long acquireTimeoutSeconds) {
-        return new ConcurrentLimitedAiInferenceService(
-                gatewayAiInferenceService, maxConcurrent, acquireTimeoutSeconds);
+        return new ConcurrentLimitedAiInferenceService(gatewayAiInferenceService, maxConcurrent, acquireTimeoutSeconds);
     }
 }

--- a/src/main/java/backend/drawrace/global/config/AiInferenceConcurrencyConfiguration.java
+++ b/src/main/java/backend/drawrace/global/config/AiInferenceConcurrencyConfiguration.java
@@ -1,0 +1,26 @@
+package backend.drawrace.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import backend.drawrace.domain.round.service.AiInferenceService;
+import backend.drawrace.domain.round.service.ConcurrentLimitedAiInferenceService;
+import backend.drawrace.domain.round.service.GatewayAiInferenceService;
+
+@Configuration
+@ConditionalOnBean(GatewayAiInferenceService.class)
+public class AiInferenceConcurrencyConfiguration {
+
+    @Bean
+    @Primary
+    public AiInferenceService boundedAiInferenceService(
+            GatewayAiInferenceService gatewayAiInferenceService,
+            @Value("${ai.inference.max-concurrent:4}") int maxConcurrent,
+            @Value("${ai.inference.acquire-timeout-seconds:120}") long acquireTimeoutSeconds) {
+        return new ConcurrentLimitedAiInferenceService(
+                gatewayAiInferenceService, maxConcurrent, acquireTimeoutSeconds);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -37,6 +37,9 @@ jwt:
 
 ai:
   mode: ${AI_MODE:quickdraw}
+  inference:
+    max-concurrent: ${AI_INFERENCE_MAX_CONCURRENT:4}
+    acquire-timeout-seconds: ${AI_INFERENCE_ACQUIRE_TIMEOUT_SECONDS:120}
   gateway:
     base-url: ${AI_GATEWAY_BASE_URL:}
     api-key: ${AI_GATEWAY_API_KEY:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,11 @@ jwt:
 
 ai:
   mode: quickdraw
+  inference:
+    # 게이트웨이 동시 호출 상한 (방 최대 인원과 맞추는 것을 권장)
+    max-concurrent: 4
+    # 세마포어 획득 대기 초. 0이면 무제한 대기(큐에 쌓임)
+    acquire-timeout-seconds: 120
   gateway:
     base-url: ${AI_GATEWAY_BASE_URL:}
     api-key: ${AI_GATEWAY_API_KEY:}

--- a/src/test/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceServiceTest.java
@@ -1,0 +1,111 @@
+package backend.drawrace.domain.round.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import backend.drawrace.domain.round.dto.AiInferenceResponse;
+import backend.drawrace.global.exception.ServiceException;
+
+class ConcurrentLimitedAiInferenceServiceTest {
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = Executors.newFixedThreadPool(8);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    void infer_respectsMaxConcurrent() throws Exception {
+        AtomicInteger concurrent = new AtomicInteger(0);
+        AtomicInteger maxSeen = new AtomicInteger(0);
+        CountDownLatch insideInfer = new CountDownLatch(2);
+        CountDownLatch releaseGate = new CountDownLatch(1);
+
+        AiInferenceService delegate = Mockito.mock(AiInferenceService.class);
+        Mockito.when(delegate.infer(Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    int c = concurrent.incrementAndGet();
+                    maxSeen.updateAndGet(m -> Math.max(m, c));
+                    insideInfer.countDown();
+                    try {
+                        releaseGate.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    } finally {
+                        concurrent.decrementAndGet();
+                    }
+                    return new AiInferenceResponse("ok", 0.5);
+                });
+
+        ConcurrentLimitedAiInferenceService limited =
+                new ConcurrentLimitedAiInferenceService(delegate, 2, 5);
+
+        Future<AiInferenceResponse> f1 = executor.submit(() -> limited.infer("img", "k"));
+        Future<AiInferenceResponse> f2 = executor.submit(() -> limited.infer("img", "k"));
+        Future<AiInferenceResponse> f3 = executor.submit(() -> limited.infer("img", "k"));
+
+        assertThat(insideInfer.await(3, TimeUnit.SECONDS)).isTrue();
+        assertThat(maxSeen.get()).isLessThanOrEqualTo(2);
+
+        releaseGate.countDown();
+
+        f1.get(5, TimeUnit.SECONDS);
+        f2.get(5, TimeUnit.SECONDS);
+        f3.get(5, TimeUnit.SECONDS);
+
+        verify(delegate, times(3)).infer(Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    void infer_timesOutWhenSlotsNeverFree() throws Exception {
+        CountDownLatch hold = new CountDownLatch(1);
+
+        AiInferenceService delegate = Mockito.mock(AiInferenceService.class);
+        Mockito.when(delegate.infer(Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    hold.await(30, TimeUnit.SECONDS);
+                    return new AiInferenceResponse("ok", 0.5);
+                });
+
+        ConcurrentLimitedAiInferenceService limited =
+                new ConcurrentLimitedAiInferenceService(delegate, 1, 1);
+
+        Future<?> blocker = executor.submit(() -> limited.infer("img", "k"));
+        Thread.sleep(100);
+
+        assertThatThrownBy(() -> limited.infer("img", "k"))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("resultCode", "503-1");
+
+        hold.countDown();
+        blocker.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void infer_invalidMaxConcurrent_throws() {
+        AiInferenceService delegate = Mockito.mock(AiInferenceService.class);
+        assertThatThrownBy(() -> new ConcurrentLimitedAiInferenceService(delegate, 0, 10))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceServiceTest.java
+++ b/src/test/java/backend/drawrace/domain/round/service/ConcurrentLimitedAiInferenceServiceTest.java
@@ -42,24 +42,22 @@ class ConcurrentLimitedAiInferenceServiceTest {
         CountDownLatch releaseGate = new CountDownLatch(1);
 
         AiInferenceService delegate = Mockito.mock(AiInferenceService.class);
-        Mockito.when(delegate.infer(Mockito.anyString(), Mockito.anyString()))
-                .thenAnswer(invocation -> {
-                    int c = concurrent.incrementAndGet();
-                    maxSeen.updateAndGet(m -> Math.max(m, c));
-                    insideInfer.countDown();
-                    try {
-                        releaseGate.await(5, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException(e);
-                    } finally {
-                        concurrent.decrementAndGet();
-                    }
-                    return new AiInferenceResponse("ok", 0.5);
-                });
+        Mockito.when(delegate.infer(Mockito.anyString(), Mockito.anyString())).thenAnswer(invocation -> {
+            int c = concurrent.incrementAndGet();
+            maxSeen.updateAndGet(m -> Math.max(m, c));
+            insideInfer.countDown();
+            try {
+                releaseGate.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } finally {
+                concurrent.decrementAndGet();
+            }
+            return new AiInferenceResponse("ok", 0.5);
+        });
 
-        ConcurrentLimitedAiInferenceService limited =
-                new ConcurrentLimitedAiInferenceService(delegate, 2, 5);
+        ConcurrentLimitedAiInferenceService limited = new ConcurrentLimitedAiInferenceService(delegate, 2, 5);
 
         Future<AiInferenceResponse> f1 = executor.submit(() -> limited.infer("img", "k"));
         Future<AiInferenceResponse> f2 = executor.submit(() -> limited.infer("img", "k"));
@@ -82,14 +80,12 @@ class ConcurrentLimitedAiInferenceServiceTest {
         CountDownLatch hold = new CountDownLatch(1);
 
         AiInferenceService delegate = Mockito.mock(AiInferenceService.class);
-        Mockito.when(delegate.infer(Mockito.anyString(), Mockito.anyString()))
-                .thenAnswer(invocation -> {
-                    hold.await(30, TimeUnit.SECONDS);
-                    return new AiInferenceResponse("ok", 0.5);
-                });
+        Mockito.when(delegate.infer(Mockito.anyString(), Mockito.anyString())).thenAnswer(invocation -> {
+            hold.await(30, TimeUnit.SECONDS);
+            return new AiInferenceResponse("ok", 0.5);
+        });
 
-        ConcurrentLimitedAiInferenceService limited =
-                new ConcurrentLimitedAiInferenceService(delegate, 1, 1);
+        ConcurrentLimitedAiInferenceService limited = new ConcurrentLimitedAiInferenceService(delegate, 1, 1);
 
         Future<?> blocker = executor.submit(() -> limited.infer("img", "k"));
         Thread.sleep(100);


### PR DESCRIPTION
## 📌 작업 개요

동시에 여러 사용자가 그림을 제출할 때 외부 AI Gateway로 AI 판별 요청이 한꺼번에 몰리면서, 일부 요청에서 응답 지연·파싱 실패·제출 실패가 발생하는 문제를 완화했습니다.

이번 수정에서는 AI 서버를 여러 개 두는 것이 아니라, **같은 AI Gateway로 동시에 요청을 보내는 통로 수를 제한**했습니다.

즉, 기존에는 여러 사용자가 동시에 제출하면 모든 AI 판별 요청이 한 번에 외부 Gateway로 나갔지만, 이제는 설정된 개수만큼만 동시에 요청하고 나머지는 대기하도록 변경했습니다.

---

## ✅ 주요 변경 사항

### 1. `ConcurrentLimitedAiInferenceService` 추가

`Semaphore`를 사용해 동시에 실제 AI 판별 요청이 실행되는 개수를 제한했습니다.

```java
new Semaphore(maxConcurrent, true)