### PR TITLE
[Fix] 채팅 로직 수정 및 게임 로직 수정

### DIFF
--- a/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
+++ b/src/main/java/backend/drawrace/domain/chat/controller/ChatController.java
@@ -29,6 +29,10 @@ public class ChatController {
     public void sendChatMessage(
             @DestinationVariable Long roomId, ChatMessageDto chatMessage, Authentication authentication) {
 
+        // 메시지마다 고유 ID 생성
+        String messageId = java.util.UUID.randomUUID().toString();
+        chatMessage.setMessageId(messageId);
+
         // 빈 메시지나 공백만 있는 메시지
         if (chatMessage.getMessage() == null || chatMessage.getMessage().trim().isEmpty()) {
             return; // 아무것도 하지 않고 종료
@@ -42,10 +46,6 @@ public class ChatController {
         User user = userRepository
                 .findById(securityUser.getUserId())
                 .orElseThrow(() -> new ServiceException("404-1", "유저를 찾을 수 없습니다."));
-
-        // 메시지마다 고유 ID 생성
-        String messageId = java.util.UUID.randomUUID().toString();
-        chatMessage.setMessageId(messageId);
 
         // AI 검열 실행
         String filteredMessage = chatModerationService.fastFilter(securityUser.getUserId(), chatMessage.getMessage());

--- a/src/main/java/backend/drawrace/domain/round/dto/SubmitDrawingResponse.java
+++ b/src/main/java/backend/drawrace/domain/round/dto/SubmitDrawingResponse.java
@@ -22,6 +22,8 @@ public class SubmitDrawingResponse {
 
     private Long roundWinnerParticipantId;
 
+    private int timeLimit; // 타이머
+
     // 라운드 승자의 AI 판별 결과
     private String roundWinnerAiAnswer;
     private Double roundWinnerScore;

--- a/src/main/java/backend/drawrace/domain/round/service/RoundService.java
+++ b/src/main/java/backend/drawrace/domain/round/service/RoundService.java
@@ -170,6 +170,9 @@ public class RoundService {
             }
         }
 
+        round.finish();
+        roundSubmissionRepository.flush();
+
         long count = roundSubmissionRepository.countActiveByRoundId(round.getId());
 
         AiInferenceResponse dummyResult = new AiInferenceResponse(round.getKeyword(), 0.0);
@@ -217,6 +220,40 @@ public class RoundService {
                 roundSubmissionRepository.existsByRoundIdAndParticipantId(round.getId(), participant.getId());
         roundValidator.validateNotSubmitted(alreadySubmitted);
 
+        AiInferenceResponse aiResult;
+        try {
+            if (participant.getUserId().isAi()) {
+                double score = 0.70 + ThreadLocalRandom.current().nextDouble(0.15);
+                aiResult = new AiInferenceResponse(round.getKeyword(), score);
+            } else {
+                aiResult = aiInferenceService.infer(request.getImageData(), round.getKeyword());
+            }
+        } catch (Exception e) {
+            aiResult = new AiInferenceResponse("ERROR", 0.0);
+        }
+
+        Round lockedRound = roundRepository
+                .findByIdForUpdate(roundId)
+                .orElseThrow(() -> new ServiceException("404-2", "존재하지 않는 라운드입니다."));
+
+        if (lockedRound.getStatus() == RoundStatus.FINISHED) {
+            log.info("AI 추론 중 타임아웃 발생. 이 결과는 무시합니다. userId={}", userId);
+            return SubmitDrawingResponse.builder().roundFinished(true).build();
+        }
+
+        roundValidator.validateRoundInProgress(lockedRound);
+
+        /*
+        // 이번 라운드 제출 대상인지 확인
+        boolean canPlay =
+                roundParticipantRepository.existsByRoundIdAndParticipantId(round.getId(), participant.getId());
+        roundValidator.validateRoundParticipant(canPlay);
+
+        // 이미 제출했는지 확인
+        boolean alreadySubmitted =
+                roundSubmissionRepository.existsByRoundIdAndParticipantId(round.getId(), participant.getId());
+        roundValidator.validateNotSubmitted(alreadySubmitted);
+
         // AI는 스트로크 데이터를 비전 모델로 판독할 수 없으므로 점수를 고정한다 (0.70~0.85)
         // 인간이 잘 그리면 AI를 이길 수 있는 수준으로 설정
         AiInferenceResponse aiResult;
@@ -227,16 +264,19 @@ public class RoundService {
             aiResult = aiInferenceService.infer(request.getImageData(), round.getKeyword());
         }
 
+
+
         /*
          * 동시 제출: infer는 네트워크 I/O로 길어 락 밖에서 수행하고,
          * 저장·count·라운드 종료 판정 전에 라운드 행에 배타 락을 걸어 submittedCount 레이스를 방지한다.
          */
+        /*
         Round lockedRound = roundRepository
                 .findByIdForUpdate(roundId)
                 .orElseThrow(() -> new ServiceException("404-2", "존재하지 않는 라운드입니다."));
 
         roundValidator.validateRoundInProgress(lockedRound);
-
+         */
         Participant lockedParticipant = getValidParticipant(lockedRound, request.getParticipantId());
 
         if (lockedParticipant.isLeft()) {
@@ -274,6 +314,7 @@ public class RoundService {
                     .submittedScore(aiResult.getScore())
                     .submittedCount((int) submittedCount)
                     .totalParticipantCount((int) totalParticipantCount)
+                    .timeLimit(ROUND_TIME_LIMIT)
                     .roundFinished(false)
                     .gameFinished(false)
                     .tieBreakerStarted(false)
@@ -429,6 +470,7 @@ public class RoundService {
                     .roundWinnerAiAnswer(winnerSubmission.getAiAnswer())
                     .roundWinnerScore(winnerSubmission.getScore())
                     .finalWinnerParticipantId(roundWinner.getId())
+                    .timeLimit(ROUND_TIME_LIMIT)
                     .build();
         }
 
@@ -446,6 +488,7 @@ public class RoundService {
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
+                    .timeLimit(ROUND_TIME_LIMIT)
                     .submittedAiAnswer(submittedAiResult.getAiAnswer())
                     .submittedScore(submittedAiResult.getScore())
                     .submittedCount((int) submittedCount)
@@ -495,6 +538,7 @@ public class RoundService {
 
             return SubmitDrawingResponse.builder()
                     .roundId(round.getId())
+                    .timeLimit(ROUND_TIME_LIMIT)
                     .submittedAiAnswer(submittedAiResult.getAiAnswer())
                     .submittedScore(submittedAiResult.getScore())
                     .submittedCount((int) submittedCount)
@@ -518,6 +562,7 @@ public class RoundService {
 
         return SubmitDrawingResponse.builder()
                 .roundId(round.getId())
+                .timeLimit(ROUND_TIME_LIMIT)
                 .submittedAiAnswer(submittedAiResult.getAiAnswer())
                 .submittedScore(submittedAiResult.getScore())
                 .submittedCount((int) submittedCount)


### PR DESCRIPTION
## 📝 작업 내용
- 라운드 진행 중 발생하는 타이머 동기화 오류와 AI 추론  게임 멈춤 현상 수정 작업 입니다.

## 🔢 작업 단계
- [ ] SubmitDrawingResponse DTO에 timeLimit 필드를 추가하여 서버의 제한 시간을 클라이언트에 명시적으로 전달합니다.
- [ ] AI 추론(infer) 완료 후 배타적 락(findByIdForUpdate)을 획득하여 라운드 상태를 재확인합니다.
- [ ] 추론 중 타임아웃(5초 대기)이 먼저 발생하여 라운드가 종료된 경우, 해당 AI 결과를 무시함으로써 결과창 중복 출력을 방지했습니다.
- [ ] 메시지별 UUID 부여 및 필터링 흐름을 정리하여 안정성을 높였습니다.

## 🧐 리뷰 포인트
- 

## ✅ 체크리스트
- [ ] 빌드가 정상적으로 완료되었나요?
- [ ] 테스트 코드를 작성하고 통과했나요?
- [ ] 팀 내 코드 컨벤션을 준수했나요?

## 📸 스크린샷 (선택)
## 🔗 관련 이슈
- Close #